### PR TITLE
Make arrays less lenient for schema types

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,4 +1,4 @@
 [bumpversion]
-current_version = 0.0.0
+current_version = 0.1.0
 files = properties/__init__.py
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,4 @@
+[bumpversion]
+current_version = 0.0.0
+files = properties/__init__.py
+

--- a/properties/__init__.py
+++ b/properties/__init__.py
@@ -6,7 +6,7 @@ import vmath
 from .spatial import *
 
 
-__version__   = '0.0.1'
+__version__   = '0.0.0'
 __author__    = '3point Science, Inc.'
 __license__   = 'MIT'
 __copyright__ = 'Copyright 2016 3point Science, Inc.'

--- a/properties/__init__.py
+++ b/properties/__init__.py
@@ -6,7 +6,7 @@ import vmath
 from .spatial import *
 
 
-__version__   = '0.0.0'
+__version__   = '0.1.0'
 __author__    = '3point Science, Inc.'
 __license__   = 'MIT'
 __copyright__ = 'Copyright 2016 3point Science, Inc.'

--- a/properties/array.py
+++ b/properties/array.py
@@ -66,8 +66,6 @@ class Array(Property):
             raise ValueError('%s must be a list or numpy array'%self.name)
         proposed = np.array(proposed)
         self._schemaFunction(proposed)
-        if self.dtype is not None:
-            proposed = proposed.astype(self.dtype)
         return proposed
 
     def fromJSON(self, value):

--- a/properties/array.py
+++ b/properties/array.py
@@ -38,14 +38,13 @@ class Array(Property):
         if getattr(self, '__schemaFunction', None) is not None:
             return self.__schemaFunction
 
-        if dtype not in (int, float, None):
-            raise TypeError("%s: Invalid dtype - must be int, float, or None")
+        if self.dtype not in (int, float, None):
+            raise TypeError("%s: Invalid dtype for %s - must be int, float, or None"%(self.dtype, self.name))
         if type(self.shape) is not tuple:
-            raise TypeError("%s: Invalid shape - must be a tuple (e.g. ('*',3) for an array of length-3 arrays)"%str(shape))
+            raise TypeError("%s: Invalid shape for %s - must be a tuple (e.g. ('*',3) for an array of length-3 arrays)"%(self.shape, self.name))
         for s in self.shape:
                 if s != '*' and type(s) != int:
-                    raise TypeError("%s: Invalid shape - values must be '*' or ints"%str(self.shape))
-        _checkShape(self.shape)
+                    raise TypeError("%s: Invalid shape for %s - values must be '*' or ints"%(self.shape, self.name))
 
         def testFunction(proposed):
             errStr=self.name
@@ -54,7 +53,7 @@ class Array(Property):
             if self.dtype == float and proposed.dtype.kind != 'f':
                 raise ValueError('%s: Array type must be float'%errStr)
             if len(self.shape) != proposed.ndim:
-                raise ValueError('%s: Array must have %d dimensions (shape: %s)'%(errStr, len(self.shape), str(self.shape)))
+                raise ValueError('%s: Array must have %d dimensions (shape: %s)'%(errStr, len(self.shape), self.shape))
             for i, s in enumerate(self.shape):
                 if s != '*' and proposed.shape[i] != s:
                     raise ValueError('%s: Array dimension %d must be length %d'%(errStr, i, s))

--- a/properties/array.py
+++ b/properties/array.py
@@ -10,7 +10,7 @@ FileProp = namedtuple('FileProp', ['file', 'dtype'])
 class Array(Property):
     """Array Property"""
 
-    shape = ('*')
+    shape = ('*',)
     dtype = float
 
     def __init__(self, doc, **kwargs):

--- a/properties/array.py
+++ b/properties/array.py
@@ -15,7 +15,7 @@ class Array(Property):
 
     def __init__(self, doc, **kwargs):
         super(self.__class__, self).__init__(doc, **kwargs)
-        self.doc = self.doc + ', Schema: %s.%s'%(str(self.shape), dtype.__name__)
+        self.doc = self.doc + ', shape: %s, type: %s'%(self.shape, self.dtype)
 
     def serialize(self, data):
         """Convert the array data to a serialized binary format"""

--- a/properties/array.py
+++ b/properties/array.py
@@ -65,10 +65,7 @@ class Array(Property):
             if typeString == 'int' and proposed.dtype.kind != 'i':
                 raise ValueError('%s: Array type must be int'%errStr)
             if typeString == 'float' and proposed.dtype.kind != 'f':
-                if proposed.dtype.kind == 'i':
-                    proposed=proposed.astype('float')
-                else:
-                    raise ValueError('%s: Array type must be float'%errStr)
+                raise ValueError('%s: Array type must be float'%errStr)
             if typeString == 'str' and proposed.dtype.kind != 'S':
                 raise ValueError('%s: Array type must be string'%errStr)
             if len(sizes) != proposed.ndim:

--- a/properties/array.py
+++ b/properties/array.py
@@ -63,20 +63,14 @@ class Array(Property):
         def testFunction(proposed):
             errStr=self.name
             if typeString == 'int' and proposed.dtype.kind != 'i':
-                try:
-                    proposed=proposed.astype('int')
-                except:
-                    raise ValueError('%s: Array type must be int'%errStr)
+                raise ValueError('%s: Array type must be int'%errStr)
             if typeString == 'float' and proposed.dtype.kind != 'f':
                 try:
                     proposed=proposed.astype('float')
                 except:
                     raise ValueError('%s: Array type must be float'%errStr)
             if typeString == 'str' and proposed.dtype.kind != 'S':
-                try:
-                    proposed=proposed.astype('string')
-                except:
-                    raise ValueError('%s: Array type must be string'%errStr)
+                raise ValueError('%s: Array type must be string'%errStr)
             if len(sizes) != proposed.ndim:
                 raise ValueError('%s: Array must have %d dimensions (schema: %s)'%(errStr, len(sizes), self.schema))
             for i, v in enumerate(sizes):

--- a/properties/array.py
+++ b/properties/array.py
@@ -65,9 +65,9 @@ class Array(Property):
             if typeString == 'int' and proposed.dtype.kind != 'i':
                 raise ValueError('%s: Array type must be int'%errStr)
             if typeString == 'float' and proposed.dtype.kind != 'f':
-                try:
+                if proposed.dtype.kind == 'i':
                     proposed=proposed.astype('float')
-                except:
+                else:
                     raise ValueError('%s: Array type must be float'%errStr)
             if typeString == 'str' and proposed.dtype.kind != 'S':
                 raise ValueError('%s: Array type must be string'%errStr)

--- a/properties/basic.py
+++ b/properties/basic.py
@@ -93,7 +93,7 @@ class Color(Property):
         if len(value) != 3:
             raise ValueError('%s: Color must be length 3'%(value,))
         for v in value:
-            if type(v) not in [int, long] or v < 0 or v > 255:
+            if type(v) not in [int, long] or not(0 <= v <= 255):
                 raise ValueError('%s: Color values must be ints 0-255.'%(value,))
         return tuple(value)
 

--- a/properties/vmath/plane.py
+++ b/properties/vmath/plane.py
@@ -70,9 +70,9 @@ class Plane(object):
         self.normal = (b-a).cross(c-a).normalize()
 
     def _fromStrikeAndDip(self, s, d, pt):
-        if s < -180 or s > 360:
+        if not (-180 <= s <= 360):
             raise ValueError('Strike must be value between 0 and 360: %4.2f'%s)
-        if d < 0 or d > 90:
+        if not (0 <= d <= 90):
             raise ValueError('Dip must be value between 0 and 90: %4.2f'%s)
         N = Matrix3(-s,'Z')*(Matrix3(d,'Y')*Vector(0,0,1))
         self._fromNormalAndPoint(N, pt)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,7 +3,7 @@ if __name__ == '__main__':
     import glob
     import unittest
     test_file_strings = glob.glob('test_*.py')
-    module_strings = [str[0:len(str)-3] for str in test_file_strings]
+    module_strings = [str[0:-3] for str in test_file_strings]
     suites = [unittest.defaultTestLoader.loadTestsFromName(str) for str
               in module_strings]
     testSuite = unittest.TestSuite(suites)


### PR DESCRIPTION
I allowed some type conversion to validate the schema in arrays. This is good for floats, I think (eg, ints get converted to floats), but not good for ints (floats shouldn't get converted to ints).