### PR TITLE
Handle unicode class name in Python 2.7

### DIFF
--- a/properties/base.py
+++ b/properties/base.py
@@ -112,7 +112,7 @@ class PropertyMetaclass(type):
 
         # Create the new class
         newcls = super(PropertyMetaclass, mcs).__new__(
-            mcs, name, bases, classdict
+            mcs, str(name), bases, classdict
         )
 
         # Save the class in the registry


### PR DESCRIPTION
Handle the case when the properties metaclass is called directly (as w/ `type`), and is given a unicode string as the new class name in Python 2.7.