### PR TITLE
Allow ordering of parameters in the docs

### DIFF
--- a/properties/base.py
+++ b/properties/base.py
@@ -87,14 +87,14 @@ class PropertyMetaclass(type):
             classdict[key] = hand.func
 
         # Document Properties
-        _doc_order = classdict.pop('_doc_order', [])
-        if not isinstance(_doc_order, (list, tuple)):
+        _doc_order = classdict.pop('_doc_order', None)
+        if _doc_order is None:
+            _doc_order = sorted(_props)
+        elif not isinstance(_doc_order, (list, tuple)):
             raise AttributeError(
                 '_doc_order must be a list of property names'
             )
-        if len(_doc_order) == 0:
-            _doc_order = sorted(_props)
-        if sorted(list(_doc_order)) != sorted(_props):
+        elif sorted(list(_doc_order)) != sorted(_props):
             raise AttributeError(
                 '_doc_order must be unspecified or contain ALL property names'
             )

--- a/properties/base.py
+++ b/properties/base.py
@@ -24,7 +24,7 @@ class PropertyMetaclass(type):
     docstrings, and add HasProperties class to Registry
     """
 
-    def __new__(mcs, name, bases, classdict):                                  #pylint: disable=too-many-locals
+    def __new__(mcs, name, bases, classdict):                                  #pylint: disable=too-many-locals, too-many-branches
 
         # Grab all the properties, observers, and validators
         prop_dict = {

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -60,6 +60,31 @@ class TestBasic(unittest.TestCase):
 
         assert PropOpts(myprop=5).validate()
 
+        with self.assertRaises(AttributeError):
+            class BadDocOrder(properties.HasProperties):
+                _doc_order = 5
+
+        with self.assertRaises(AttributeError):
+            class BadDocOrder(properties.HasProperties):
+                _doc_order = ['myprop', 'another_prop']
+                myprop = properties.Property('empty property')
+
+        class WithDocOrder(properties.HasProperties):
+            _doc_order = ['myprop1', 'myprop2', 'myprop3']
+            myprop1 = properties.Property('empty property')
+            myprop2 = properties.Property('empty property')
+            myprop3 = properties.Property('empty property')
+
+        assert WithDocOrder().__doc__ == (
+            '\n\n**Required**\n\n'
+            ':param myprop1: empty property\n'
+            ':type myprop1: :class:`Property <properties.basic.Property>`\n'
+            ':param myprop2: empty property\n'
+            ':type myprop2: :class:`Property <properties.basic.Property>`\n'
+            ':param myprop3: empty property\n'
+            ':type myprop3: :class:`Property <properties.basic.Property>`'
+        )
+
     def test_bool(self):
 
         class BoolOpts(properties.HasProperties):


### PR DESCRIPTION
Introduces `_doc_order`, a list of all property names on a HasProperties class. This order will determine the order of the properties in the docs. After the docs are written, `_doc_order` is removed from the class dictionary.

Notes:
- `_doc_order` must contain ALL property names or be unspecified/empty. Otherwise an `AttributeError` will be raised on class definition.
- If `_doc_order` is not specified, the docs will be ordered alphabetically.
- `Required`/`Optional`/`Immutable` hierarchy in the docs supersedes `_doc_order`; the order will only be reflected within those sections.

See: https://github.com/3ptscience/properties/issues/58