### PR TITLE
Improve treatment of unicode by String property

### DIFF
--- a/properties/basic.py
+++ b/properties/basic.py
@@ -496,6 +496,9 @@ class String(Property):
     * **strip** - substring to strip off input
 
     * **change_case** - forces 'lower', 'upper', or None
+
+    * **unicode** - if True, coerce strings to unicode. Default is True
+      to ensure consistent behaviour across Python 2/3.
     """
 
     info_text = 'a string'
@@ -527,16 +530,31 @@ class String(Property):
                             "'lower' or None")
         self._change_case = value
 
+    @property
+    def unicode(self):
+        """Coerces string value to unicode"""
+        return getattr(self, '_unicode', True)
+
+    @unicode.setter
+    def unicode(self, value):
+        if not isinstance(value, bool):
+            raise TypeError("'unicode' property must be a boolean")
+        self._unicode = value
+
     def validate(self, instance, value):
         """Check if value is a string, and strips it and changes case"""
+        value_type = type(value)
         if not isinstance(value, string_types):
             self.error(instance, value)
-        value = text_type(value)
         value = value.strip(self.strip)
         if self.change_case == 'upper':
             value = value.upper()
         elif self.change_case == 'lower':
             value = value.lower()
+        if self.unicode:
+            value = text_type(value)
+        else:
+            value = value_type(value)
         return value
 
 

--- a/properties/basic.py
+++ b/properties/basic.py
@@ -11,6 +11,7 @@ import uuid
 import numpy as np
 from six import integer_types
 from six import string_types
+from six import text_type
 from six import with_metaclass
 
 from .utils import undefined
@@ -530,7 +531,7 @@ class String(Property):
         """Check if value is a string, and strips it and changes case"""
         if not isinstance(value, string_types):
             self.error(instance, value)
-        value = str(value)
+        value = text_type(value)
         value = value.strip(self.strip)
         if self.change_case == 'upper':
             value = value.upper()

--- a/properties/basic.py
+++ b/properties/basic.py
@@ -9,10 +9,7 @@ import datetime
 import uuid
 
 import numpy as np
-from six import integer_types
-from six import string_types
-from six import text_type
-from six import with_metaclass
+from six import integer_types, string_types, text_type, with_metaclass
 
 from .utils import undefined
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
@@ -210,6 +211,9 @@ class TestBasic(unittest.TestCase):
         assert StringOpts.deserialize(
             {'mystringupper': 'a string'}
         ).mystringupper == 'A STRING'
+
+        strings.mystring = u'∏Øˆ∏ØÎ'
+        assert strings.mystring == u'∏Øˆ∏ØÎ'
 
     def test_string_choice(self):
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -10,6 +10,7 @@ import uuid
 
 import numpy as np
 import properties
+import six
 
 
 class TestBasic(unittest.TestCase):
@@ -176,6 +177,8 @@ class TestBasic(unittest.TestCase):
             properties.String('bad strip', strip=5)
         with self.assertRaises(TypeError):
             properties.String('bad case', change_case='mixed')
+        with self.assertRaises(TypeError):
+            properties.String('bad unicode', unicode='no')
 
         class StringOpts(properties.HasProperties):
             mystring = properties.String('My string')
@@ -214,6 +217,15 @@ class TestBasic(unittest.TestCase):
 
         strings.mystring = u'∏Øˆ∏ØÎ'
         assert strings.mystring == u'∏Øˆ∏ØÎ'
+
+        class StringOpts(properties.HasProperties):
+            mystring = properties.String('my string', unicode=False)
+
+        strings = StringOpts()
+        strings.mystring = str('hi')
+        assert isinstance(strings.mystring, str)
+        strings.mystring = u'hi'
+        assert isinstance(strings.mystring, six.text_type)
 
     def test_string_choice(self):
 


### PR DESCRIPTION
String properties now are more friendly to unicode. The `unicode` attribute was added to String properties. By default this is true and all strings are coerced to unicode. If false, input string type will be maintained.

See: https://github.com/3ptscience/properties/issues/57

