### PR TITLE
Allow sets and enforce uniqueness in string choices

### DIFF
--- a/properties/basic.py
+++ b/properties/basic.py
@@ -576,8 +576,7 @@ class StringChoice(Property):
         if isinstance(value, (set, list, tuple)):
             if len(value) != len(set(value)):
                 raise TypeError("'choices' must contain no duplicate strings")
-            self._choices = {v: [] for v in value}
-            return
+            value = {v: [] for v in value}
         if not isinstance(value, dict):
             raise TypeError("'choices' must be a set, list, tuple, or dict")
         for key, val in value.items():

--- a/properties/basic.py
+++ b/properties/basic.py
@@ -573,16 +573,15 @@ class StringChoice(Property):
 
     @choices.setter
     def choices(self, value):
-        if not isinstance(value, (set, list, tuple, dict)):
-            raise TypeError("'choices' must be a set, list, tuple, or dict")
         if isinstance(value, (set, list, tuple)):
             if len(value) != len(set(value)):
                 raise TypeError("'choices' must contain no duplicate strings")
             self._choices = {v: v for v in value}
             return
+        if not isinstance(value, dict):
+            raise TypeError("'choices' must be a set, list, tuple, or dict")
         for key, val in value.items():
-            if not isinstance(val, (set, list, tuple)):
-                value[key] = [val]
+            value[key] = list(val)
         all_items = []
         for key, val in value.items():
             if not isinstance(key, string_types):

--- a/properties/basic.py
+++ b/properties/basic.py
@@ -576,12 +576,15 @@ class StringChoice(Property):
         if isinstance(value, (set, list, tuple)):
             if len(value) != len(set(value)):
                 raise TypeError("'choices' must contain no duplicate strings")
-            self._choices = {v: v for v in value}
+            self._choices = {v: [] for v in value}
             return
         if not isinstance(value, dict):
             raise TypeError("'choices' must be a set, list, tuple, or dict")
         for key, val in value.items():
-            value[key] = list(val)
+            if isinstance(val, (set, list, tuple)):
+                value[key] = list(val)
+            else:
+                value[key] = [val]
         all_items = []
         for key, val in value.items():
             if not isinstance(key, string_types):

--- a/properties/basic.py
+++ b/properties/basic.py
@@ -573,19 +573,26 @@ class StringChoice(Property):
 
     @choices.setter
     def choices(self, value):
-        if not isinstance(value, (list, tuple, dict)):
-            raise TypeError('value must be a list, tuple, or dict')
-        if isinstance(value, (list, tuple)):
-            value = {v: v for v in value}
+        if not isinstance(value, (set, list, tuple, dict)):
+            raise TypeError("'choices' must be a set, list, tuple, or dict")
+        if isinstance(value, (set, list, tuple)):
+            if len(value) != len(set(value)):
+                raise TypeError("'choices' must contain no duplicate strings")
+            self._choices = {v: v for v in value}
+            return
         for key, val in value.items():
-            if not isinstance(val, (list, tuple)):
+            if not isinstance(val, (set, list, tuple)):
                 value[key] = [val]
+        all_items = []
         for key, val in value.items():
             if not isinstance(key, string_types):
-                raise TypeError('value must be strings')
+                raise TypeError("'choices' must be strings'")
             for sub_val in val:
                 if not isinstance(sub_val, string_types):
-                    raise TypeError('value must be strings')
+                    raise TypeError("'choices' must be strings")
+            all_items = all_items + [key] + val
+        if len(all_items) != len(set(all_items)):
+            raise TypeError("'choices' must contain no duplicate strings")
         self._choices = value
 
     def validate(self, instance, value):

--- a/properties/basic.py
+++ b/properties/basic.py
@@ -587,11 +587,11 @@ class StringChoice(Property):
         all_items = []
         for key, val in value.items():
             if not isinstance(key, string_types):
-                raise TypeError("'choices' must be strings'")
+                raise TypeError("'choices' must be strings")
             for sub_val in val:
                 if not isinstance(sub_val, string_types):
                     raise TypeError("'choices' must be strings")
-            all_items = all_items + [key] + val
+            all_items += [key] + val
         if len(all_items) != len(set(all_items)):
             raise TypeError("'choices' must contain no duplicate strings")
         self._choices = value

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -219,6 +219,10 @@ class TestBasic(unittest.TestCase):
             properties.StringChoice('bad choices', {5: '5'})
         with self.assertRaises(TypeError):
             properties.StringChoice('bad choices', {'5': 5})
+        with self.assertRaises(TypeError):
+            properties.StringChoice('bad choices', ['a', 'a', 'b'])
+        with self.assertRaises(TypeError):
+            properties.StringChoice('bad choices', {'a': 'b', 'c': 'a'})
 
         class StrChoicesOpts(properties.HasProperties):
             mychoicelist = properties.StringChoice(
@@ -247,7 +251,7 @@ class TestBasic(unittest.TestCase):
         })
         assert StrChoicesOpts.deserialize(
             {'mychoicedict': 'a'}
-        ).mychoicedict == 'vowel'
+        ).mychoicedict == 'vowel'∏
 
     def test_array(self):
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -232,6 +232,12 @@ class TestBasic(unittest.TestCase):
                 'dict of choices', {'vowel': ['a', 'e', 'i', 'o', 'u'],
                                     'maybe': 'y'}
             )
+            mychoicetuple = properties.StringChoice(
+                'tuple of choices', ('a', 'e', 'i', 'o', 'u')
+            )
+            mychoiceset = properties.StringChoice(
+                'set of choices', {'a', 'e', 'i', 'o', 'u'}
+            )
 
         choices = StrChoicesOpts()
 
@@ -251,7 +257,7 @@ class TestBasic(unittest.TestCase):
         })
         assert StrChoicesOpts.deserialize(
             {'mychoicedict': 'a'}
-        ).mychoicedict == 'vowel'∏
+        ).mychoicedict == 'vowel'
 
     def test_array(self):
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -223,6 +223,8 @@ class TestBasic(unittest.TestCase):
             properties.StringChoice('bad choices', ['a', 'a', 'b'])
         with self.assertRaises(TypeError):
             properties.StringChoice('bad choices', {'a': 'b', 'c': 'a'})
+        with self.assertRaises(TypeError):
+            properties.StringChoice('bad choices', [5, 6, 7])
 
         class StrChoicesOpts(properties.HasProperties):
             mychoicelist = properties.StringChoice(


### PR DESCRIPTION
- StringChoice property attribute `choices` may now be a set in addition to list, tuple, or dict.
- If `choices` is a list or tuple, a `TypeError` will be raised if there are any repeated entries.
- If `choices` is a dictionary, a `TypeError` will be raised if there are any duplicate entries across all keys and values.
- Also dictionary values may now be tuples or sets in addition to lists

See: https://github.com/3ptscience/properties/issues/51