### PR TITLE
Rename help/helpdoc to doc

### DIFF
--- a/properties/base.py
+++ b/properties/base.py
@@ -274,11 +274,11 @@ class Instance(basic.Property):
 
     info_text = 'an instance'
 
-    def __init__(self, helpdoc, instance_class, **kwargs):
+    def __init__(self, doc, instance_class, **kwargs):
         if not isinstance(instance_class, type):
             raise TypeError('instance_class must be class')
         self.instance_class = instance_class
-        super(Instance, self).__init__(helpdoc, **kwargs)
+        super(Instance, self).__init__(doc, **kwargs)
 
     @property
     def _class_default(self):
@@ -299,7 +299,7 @@ class Instance(basic.Property):
         self._auto_create = value
 
     def info(self):
-        """Description of the property, supplemental to the help doc"""
+        """Description of the property, supplemental to the basic doc"""
         return 'an instance of {cls}'.format(cls=self.instance_class.__name__)
 
     def validate(self, instance, value):
@@ -405,13 +405,13 @@ class List(basic.Property):
     info_text = 'a list'
     _class_default = list
 
-    def __init__(self, helpdoc, prop, **kwargs):
+    def __init__(self, doc, prop, **kwargs):
         if isinstance(prop, type) and issubclass(prop, HasProperties):
-            prop = Instance(helpdoc, prop)
+            prop = Instance(doc, prop)
         if not isinstance(prop, basic.Property):
             raise TypeError('prop must be a Property or HasProperties class')
         self.prop = prop
-        super(List, self).__init__(helpdoc, **kwargs)
+        super(List, self).__init__(doc, **kwargs)
         self._unused_default_warning()
 
     @property
@@ -560,23 +560,23 @@ class Union(basic.Property):
 
     info_text = 'a union of multiple property types'
 
-    def __init__(self, helpdoc, props, **kwargs):
+    def __init__(self, doc, props, **kwargs):
         if not isinstance(props, (tuple, list)):
             raise TypeError('props must be a list')
         new_props = tuple()
         for prop in props:
             if isinstance(prop, type) and issubclass(prop, HasProperties):
-                prop = Instance(help, prop)
+                prop = Instance(doc, prop)
             if not isinstance(prop, basic.Property):
                 raise TypeError('all props must be Property instance or '
                                 'HasProperties class')
             new_props += (prop,)
         self.props = new_props
-        super(Union, self).__init__(helpdoc, **kwargs)
+        super(Union, self).__init__(doc, **kwargs)
         self._unused_default_warning()
 
     def info(self):
-        """Description of the property, supplemental to the help doc"""
+        """Description of the property, supplemental to the basic doc"""
         return ' or '.join([p.info() for p in self.props])
 
     @property

--- a/properties/basic.py
+++ b/properties/basic.py
@@ -34,7 +34,7 @@ class GettableProperty(with_metaclass(ArgumentWrangler, object)):              #
 
     Available keywords:
 
-    * **help** - property's custom help string
+    * **doc** - property's custom doc string
     * **default** - property's default value
     """
 
@@ -42,8 +42,8 @@ class GettableProperty(with_metaclass(ArgumentWrangler, object)):              #
     name = ''
     _class_default = undefined
 
-    def __init__(self, helpdoc, **kwargs):
-        self._base_help = helpdoc
+    def __init__(self, doc, **kwargs):
+        self._base_doc = doc
         self._meta = {}
         for key in kwargs:
             if key[0] == '_':
@@ -121,11 +121,11 @@ class GettableProperty(with_metaclass(ArgumentWrangler, object)):              #
         self._deserializer = value
 
     @property
-    def help(self):
-        """Get the help documentation of a Property instance"""
-        if getattr(self, '_help', None) is None:
-            self._help = self._base_help
-        return self._help
+    def doc(self):
+        """Get the doc documentation of a Property instance"""
+        if getattr(self, '_doc', None) is None:
+            self._doc = self._base_doc
+        return self._doc
 
     @property
     def meta(self):
@@ -145,7 +145,7 @@ class GettableProperty(with_metaclass(ArgumentWrangler, object)):              #
         return self
 
     def info(self):
-        """Description of the property, supplemental to the help doc"""
+        """Description of the property, supplemental to the base doc"""
         return self.info_text
 
     def validate(self, instance, value):                                       #pylint: disable=unused-argument,no-self-use
@@ -170,7 +170,7 @@ class GettableProperty(with_metaclass(ArgumentWrangler, object)):              #
             """Call the HasProperties _get method"""
             return self._get(scope.name)
 
-        return property(fget=fget, doc=scope.help)
+        return property(fget=fget, doc=scope.doc)
 
     def serialize(self, value, include_class=True):                            #pylint: disable=unused-argument
         """Serialize the property value to JSON
@@ -213,9 +213,9 @@ class GettableProperty(with_metaclass(ArgumentWrangler, object)):              #
     def sphinx(self):
         """Basic docstring formatted for Sphinx docs"""
         return (
-            ':attribute {name}: ({cls}) - {help}{info}'.format(
+            ':attribute {name}: ({cls}) - {doc}{info}'.format(
                 name=self.name,
-                help=self.help,
+                doc=self.doc,
                 info='' if self.info() == 'corrected' else ', ' + self.info(),
                 cls=self.sphinx_class(),
             )
@@ -238,10 +238,10 @@ class Property(GettableProperty):
       HasProperties instance to be valid
     """
 
-    def __init__(self, helpdoc, **kwargs):
+    def __init__(self, doc, **kwargs):
         if 'required' in kwargs:
             self.required = kwargs.pop('required')
-        super(Property, self).__init__(helpdoc, **kwargs)
+        super(Property, self).__init__(doc, **kwargs)
 
     @property
     def required(self):
@@ -294,7 +294,7 @@ class Property(GettableProperty):
             """Set value to utils.undefined on delete"""
             self._set(scope.name, undefined)
 
-        return property(fget=fget, fset=fset, fdel=fdel, doc=scope.help)
+        return property(fget=fget, fset=fset, fdel=fdel, doc=scope.doc)
 
     def error(self, instance, value, error=None, extra=''):
         """Generates a ValueError on setting property to an invalid value"""
@@ -332,9 +332,9 @@ class Property(GettableProperty):
             default_str = ', Default: {}'.format(default_str)
 
         return (
-            ':param {name}: {help}{info}{default}\n:type {name}: {cls}'.format(
+            ':param {name}: {doc}{info}{default}\n:type {name}: {cls}'.format(
                 name=self.name,
-                help=self.help,
+                doc=self.doc,
                 info='' if self.info() == 'corrected' else ', ' + self.info(),
                 default=default_str,
                 cls=self.sphinx_class(),
@@ -565,9 +565,9 @@ class StringChoice(Property):
       where any string in the value list is coerced into the key string.
     """
 
-    def __init__(self, helpdoc, choices, **kwargs):
+    def __init__(self, doc, choices, **kwargs):
         self.choices = choices
-        super(StringChoice, self).__init__(helpdoc, **kwargs)
+        super(StringChoice, self).__init__(doc, **kwargs)
 
     @property
     def info_text(self):


### PR DESCRIPTION
All this does is described in the title. Hopefully there are very few external references to either of these. The reasoning for this is to remove the name conflict with builtin `help`.