### PR TITLE
Validate floats, ints, and complex by casting, checking value, and catching errors.

### DIFF
--- a/properties/basic.py
+++ b/properties/basic.py
@@ -14,7 +14,7 @@ from six import integer_types, string_types, text_type, with_metaclass
 
 from .utils import undefined
 
-TOL = 1e-6
+TOL = 1e-9
 
 PropertyTerms = collections.namedtuple(
     'PropertyTerms',
@@ -413,12 +413,14 @@ class Integer(Property):
 
     def validate(self, instance, value):
         """Checks that value is an integer and in min/max bounds"""
-        if isinstance(value, float) and abs(value - int(value)) < TOL:
-            value = int(value)
-        if not isinstance(value, integer_types):
+        try:
+            intval = int(value)
+            if abs(value - intval) > TOL:
+                raise ValueError()
+        except (TypeError, ValueError):
             self.error(instance, value)
-        _in_bounds(self, instance, value)
-        return int(value)
+        _in_bounds(self, instance, intval)
+        return intval
 
     def info(self):
         if (getattr(self, 'min', None) is None and
@@ -443,14 +445,16 @@ class Float(Integer):
     def validate(self, instance, value):
         """Checks that value is a float and in min/max bounds
 
-        Integers are coerced to floats
+        Non-float numbers are coerced to floats
         """
-        if isinstance(value, (float, integer_types)):
-            value = float(value)
-        if not isinstance(value, float):
+        try:
+            floatval = float(value)
+            if abs(value - floatval) > TOL:
+                raise ValueError()
+        except (TypeError, ValueError):
             self.error(instance, value)
-        _in_bounds(self, instance, value)
-        return value
+        _in_bounds(self, instance, floatval)
+        return floatval
 
     @staticmethod
     def to_json(value):
@@ -473,11 +477,16 @@ class Complex(Property):
 
         Floats and Integers are coerced to complex numbers
         """
-        if isinstance(value, (integer_types, float)):
-            value = complex(value)
-        if not isinstance(value, complex):
-            raise ValueError('{} must be complex'.format(self.name))
-        return value
+        try:
+            compval = complex(value)
+            if (
+                    abs(value.real - compval.real) > TOL or
+                    abs(value.imag - compval.imag) > TOL
+            ):
+                raise ValueError()
+        except (TypeError, ValueError, AttributeError):
+            self.error(instance, value)
+        return compval
 
     @staticmethod
     def to_json(value):

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -153,6 +153,9 @@ class TestBasic(unittest.TestCase):
         assert nums.myfloat == 1.
         nums.myfloatmin = nums.myfloatmax = nums.myfloatrange = 10.
 
+        nums.myfloat = np.float32(1)
+        assert nums.myfloat == 1.
+
         assert properties.Integer.to_json(5) == 5
         assert properties.Float.to_json(5.) == 5.
         assert properties.Float.to_json(np.nan) == 'nan'


### PR DESCRIPTION
This allows using numpy float/int/complex types for example that are not
subclasses of builtin float/int/etc without importing numpy.

See: #86