### PR TITLE
Fix Array validation

### DIFF
--- a/properties/math.py
+++ b/properties/math.py
@@ -14,7 +14,6 @@ TYPE_MAPPINGS = {
     int: 'i',
     float: 'f',
     bool: 'b',
-    object: 'O',
 }
 
 
@@ -103,9 +102,8 @@ class Array(Property):
                 'Array validation is only implmented for wrappers that are '
                 'subclasses of numpy.ndarray'
             )
-        for typ, kind in TYPE_MAPPINGS.items():
-            if value.dtype.kind == kind and typ not in self.dtype:
-                self.error(instance, value)
+        if value.dtype.kind not in (TYPE_MAPPINGS[typ] for typ in self.dtype):
+            self.error(instance, value)
         if len(self.shape) != value.ndim:
             self.error(instance, value)
         for i, shp in enumerate(self.shape):

--- a/properties/math.py
+++ b/properties/math.py
@@ -14,6 +14,7 @@ TYPE_MAPPINGS = {
     int: 'i',
     float: 'f',
     bool: 'b',
+    object: 'O',
 }
 
 

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -49,6 +49,8 @@ class TestMath(unittest.TestCase):
             arrays.myarraybool = np.array([0, 1, 0])
         with self.assertRaises(ValueError):
             arrays.myarrayint = np.array([0, 1, 0]).astype(bool)
+        with self.assertRaises(ValueError):
+            arrays.myarraybool = np.array(['a', 'b', 'c'])
 
         arrays.myarraybool = np.array([0, 1, 0]).astype(bool)
 


### PR DESCRIPTION
Numpy arrays full of `object`s are now checked against the allowed `dtype`. 
Passing such an array to a new `Array` now fails the validation.