### PR TITLE
Clean up attribute setters, info, error messages

### DIFF
--- a/properties/base.py
+++ b/properties/base.py
@@ -7,16 +7,19 @@ from __future__ import unicode_literals
 from collections import OrderedDict
 import json
 import pickle
-from types import ClassType
 from warnings import warn
 
-from six import integer_types
-from six import iteritems
-from six import with_metaclass
+from six import integer_types, iteritems, PY2, with_metaclass
 
 from . import basic
 from . import handlers
 from . import utils
+
+if PY2:
+    from types import ClassType
+    CLASS_TYPES = (type, ClassType)
+else:
+    CLASS_TYPES = (type,)
 
 
 class PropertyMetaclass(type):
@@ -355,7 +358,7 @@ class Instance(basic.Property):
 
     @instance_class.setter
     def instance_class(self, value):
-        if not isinstance(value, (type, ClassType)):
+        if not isinstance(value, CLASS_TYPES):
             raise TypeError('instance_class must be a class')
         self._instance_class = value
 
@@ -490,7 +493,7 @@ class List(basic.Property):
 
     @prop.setter
     def prop(self, value):
-        if (isinstance(value, (type, ClassType)) and
+        if (isinstance(value, CLASS_TYPES) and
                 issubclass(value, HasProperties)):
             value = Instance('', value)
         if not isinstance(value, basic.Property):
@@ -663,7 +666,7 @@ class Union(basic.Property):
             raise TypeError('props must be a list')
         new_props = tuple()
         for prop in value:
-            if (isinstance(prop, (type, ClassType)) and
+            if (isinstance(prop, CLASS_TYPES) and
                     issubclass(prop, HasProperties)):
                 prop = Instance('', prop)
             if not isinstance(prop, basic.Property):

--- a/properties/base.py
+++ b/properties/base.py
@@ -355,7 +355,7 @@ class Instance(basic.Property):
 
     @instance_class.setter
     def instance_class(self, value):
-        if not isinstance(instance_class, (type, ClassType)):
+        if not isinstance(value, (type, ClassType)):
             raise TypeError('instance_class must be a class')
         self._instance_class = value
 
@@ -489,8 +489,9 @@ class List(basic.Property):
 
     @prop.setter
     def prop(self, value):
-        if isinstance(value, type) and issubclass(value, HasProperties):
-            prop = Instance(doc, value)
+        if (isinstance(value, (type, ClassType)) and
+                issubclass(value, HasProperties)):
+            value = Instance('', value)
         if not isinstance(value, basic.Property):
             raise TypeError('prop must be a Property or HasProperties class')
         self._prop = value
@@ -659,9 +660,9 @@ class Union(basic.Property):
             raise TypeError('props must be a list')
         new_props = tuple()
         for prop in value:
-            if isinstance(prop, (type, ClassType)) and
-                    issubclass(prop, HasProperties):
-                prop = Instance(doc, prop)
+            if (isinstance(prop, (type, ClassType)) and
+                    issubclass(prop, HasProperties)):
+                prop = Instance('', prop)
             if not isinstance(prop, basic.Property):
                 raise TypeError('props must be Property instances or '
                                 'HasProperties classes')

--- a/properties/base.py
+++ b/properties/base.py
@@ -654,6 +654,7 @@ class Union(basic.Property):
 
     @property
     def props(self):
+        """List of valid property types or HasProperties classes"""
         return self._props
 
     @props.setter

--- a/properties/base.py
+++ b/properties/base.py
@@ -335,7 +335,7 @@ class Instance(basic.Property):
       that requires arguments.
     """
 
-    info_text = 'an instance'
+    class_info = 'an instance'
 
     def __init__(self, doc, instance_class, **kwargs):
         self.instance_class = instance_class
@@ -370,6 +370,7 @@ class Instance(basic.Property):
             raise TypeError('auto_create must be a boolean')
         self._auto_create = value
 
+    @property
     def info(self):
         """Description of the property, supplemental to the basic doc"""
         return 'an instance of {cls}'.format(cls=self.instance_class.__name__)
@@ -474,7 +475,7 @@ class List(basic.Property):
     * **min_length**/**max_length** - valid length limits of the list
     """
 
-    info_text = 'a list'
+    class_info = 'a list'
     _class_default = list
 
     def __init__(self, doc, prop, **kwargs):
@@ -536,9 +537,10 @@ class List(basic.Property):
             raise TypeError('max_length must be >= min_length')
         self._max_length = value
 
+    @property
     def info(self):
         """Supplemental description of the list, with length and type"""
-        itext = 'a list (each item is {info})'.format(info=self.prop.info())
+        itext = 'a list (each item is {info})'.format(info=self.prop.info)
         if self.max_length is None and self.min_length is None:
             return itext
         if self.max_length is None:
@@ -643,7 +645,7 @@ class Union(basic.Property):
       be HasProperties classes
     """
 
-    info_text = 'a union of multiple property types'
+    class_info = 'a union of multiple property types'
 
     def __init__(self, doc, props, **kwargs):
         self.props = props
@@ -669,10 +671,10 @@ class Union(basic.Property):
             new_props += (prop,)
         self._props = new_props
 
-
+    @property
     def info(self):
         """Description of the property, supplemental to the basic doc"""
-        return ' or '.join([p.info() for p in self.props])
+        return ' or '.join([p.info for p in self.props])
 
     @property
     def name(self):

--- a/properties/base.py
+++ b/properties/base.py
@@ -16,7 +16,7 @@ from . import handlers
 from . import utils
 
 if PY2:
-    from types import ClassType
+    from types import ClassType                                                #pylint: disable=no-name-in-module
     CLASS_TYPES = (type, ClassType)
 else:
     CLASS_TYPES = (type,)

--- a/properties/basic.py
+++ b/properties/basic.py
@@ -499,11 +499,17 @@ class Property(GettableProperty):
     def error(self, instance, value, error=None, extra=''):
         """Generates a ValueError on setting property to an invalid value"""
         error = error if error is not None else ValueError
-        raise error(
-            "The '{name}' property of a {cls} instance must be {info}. "
-            "A value of {val!r} {vtype!r} was specified. {extra}".format(
+        if instance is None:
+            prefix = '{} property'.format(self.__class__.__name__)
+        else:
+            prefix = "The '{name}' property of a {cls} instance".format(
                 name=self.name,
                 cls=instance.__class__.__name__,
+            )
+        raise error(
+            '{prefix} must be {info}. A value of {val!r} {vtype!r} was '
+            'specified. {extra}'.format(
+                prefix=prefix,
                 info=self.info,
                 val=value,
                 vtype=type(value),

--- a/properties/basic.py
+++ b/properties/basic.py
@@ -9,6 +9,7 @@ import datetime
 import math
 import random
 import uuid
+from warnings import warn
 
 from six import integer_types, string_types, text_type, with_metaclass
 
@@ -25,6 +26,24 @@ PropertyTerms = collections.namedtuple(
 class ArgumentWrangler(type):
     """Stores arguments to property initialization for later use"""
 
+    def __new__(mcs, name, bases, classdict):
+
+        # Backward compatibility:
+        if 'info_text' in classdict:
+            warn('Deprecation warning: info_text has been renamed class_info. '
+                 'Consider updating class {} '.format(name), FutureWarning)
+            classdict['class_info'] = classdict['info_text']
+        if 'info' in classdict and callable(classdict['info']):
+            warn('Deprecation warning: info is now a @property, not a '
+                 'callable. Consider updating class {}'.format(name),
+                 FutureWarning)
+            classdict['info'] = property(fget=classdict['info'])
+
+        newcls = super(ArgumentWrangler, mcs).__new__(
+            mcs, name, bases, classdict
+        )
+        return newcls
+
     def __call__(cls, *args, **kwargs):
         """Wrap __init__ call in GettableProperty subclasses"""
         instance = super(ArgumentWrangler, cls).__call__(*args, **kwargs)
@@ -40,7 +59,7 @@ class GettableProperty(with_metaclass(ArgumentWrangler, object)):              #
     * **doc** - property's custom doc string
     * **default** - property's default value
     """
-    info_text = 'corrected'
+    class_info = 'corrected'
     name = ''
     _class_default = undefined
 
@@ -150,9 +169,10 @@ class GettableProperty(with_metaclass(ArgumentWrangler, object)):              #
         self._meta.update(kwtags)
         return self
 
+    @property
     def info(self):
         """Description of the property, supplemental to the base doc"""
-        return self.info_text
+        return self.class_info
 
     def validate(self, instance, value):                                       #pylint: disable=unused-argument,no-self-use
         """Check if value is valid and possibly coerce it to new value"""
@@ -222,7 +242,7 @@ class GettableProperty(with_metaclass(ArgumentWrangler, object)):              #
             ':attribute {name}: ({cls}) - {doc}{info}'.format(
                 name=self.name,
                 doc=self.doc,
-                info='' if self.info() == 'corrected' else ', ' + self.info(),
+                info='' if self.info == 'corrected' else ', ' + self.info,
                 cls=self.sphinx_class(),
             )
         )
@@ -484,7 +504,7 @@ class Property(GettableProperty):
             "A value of {val!r} {vtype!r} was specified. {extra}".format(
                 name=self.name,
                 cls=instance.__class__.__name__,
-                info=self.info(),
+                info=self.info,
                 val=value,
                 vtype=type(value),
                 extra=extra,
@@ -515,7 +535,7 @@ class Property(GettableProperty):
             ':param {name}: {doc}{info}{default}\n:type {name}: {cls}'.format(
                 name=self.name,
                 doc=self.doc,
-                info='' if self.info() == 'corrected' else ', ' + self.info(),
+                info='' if self.info == 'corrected' else ', ' + self.info,
                 default=default_str,
                 cls=self.sphinx_class(),
             )
@@ -525,7 +545,7 @@ class Property(GettableProperty):
 class Bool(Property):
     """Boolean property"""
 
-    info_text = 'a boolean'
+    class_info = 'a boolean'
 
     def validate(self, instance, value):
         """Checks if value is a boolean"""
@@ -564,7 +584,7 @@ class Integer(Property):
     * **min**/**max** - set valid bounds of property
     """
 
-    info_text = 'an integer'
+    class_info = 'an integer'
 
     @property
     def min(self):
@@ -599,12 +619,13 @@ class Integer(Property):
         _in_bounds(self, instance, intval)
         return intval
 
+    @property
     def info(self):
         if (getattr(self, 'min', None) is None and
                 getattr(self, 'max', None) is None):
-            return self.info_text
+            return self.class_info
         return '{txt} in range [{mn}, {mx}]'.format(
-            txt=self.info_text,
+            txt=self.class_info,
             mn='-inf' if getattr(self, 'min', None) is None else self.min,
             mx='inf' if getattr(self, 'max', None) is None else self.max
         )
@@ -617,7 +638,7 @@ class Integer(Property):
 class Float(Integer):
     """Float property"""
 
-    info_text = 'a float'
+    class_info = 'a float'
 
     def validate(self, instance, value):
         """Checks that value is a float and in min/max bounds
@@ -647,7 +668,7 @@ class Float(Integer):
 class Complex(Property):
     """Complex number property"""
 
-    info_text = 'a complex number'
+    class_info = 'a complex number'
 
     def validate(self, instance, value):
         """Checks that value is a complex number
@@ -687,7 +708,7 @@ class String(Property):
       to ensure consistent behaviour across Python 2/3.
     """
 
-    info_text = 'a string'
+    class_info = 'a string'
 
     @property
     def strip(self):
@@ -754,12 +775,14 @@ class StringChoice(Property):
       where any string in the value list is coerced into the key string.
     """
 
+    class_info = 'a string choice'
+
     def __init__(self, doc, choices, **kwargs):
         self.choices = choices
         super(StringChoice, self).__init__(doc, **kwargs)
 
     @property
-    def info_text(self):
+    def info(self):
         """Formatted string to display the available choices"""
         if len(self.choices) == 2:
             return 'either "{}" or "{}"'.format(list(self.choices)[0],
@@ -826,7 +849,7 @@ class Color(Property):
     standard `web-colors <https://en.wikipedia.org/wiki/Web_colors>`_.
     """
 
-    info_text = 'a color'
+    class_info = 'a color'
 
     def validate(self, instance, value):
         """Check if input is valid color and converts to RGB"""
@@ -879,7 +902,7 @@ class DateTime(Property):
             1995/08/12 and 1995-08-12T18:00:00Z
     """
 
-    info_text = 'a datetime object'
+    class_info = 'a datetime object'
 
     def validate(self, instance, value):
         """Check if value is a valid datetime object or JSON datetime string"""
@@ -907,7 +930,7 @@ class DateTime(Property):
 class Uuid(GettableProperty):
     """Unique identifier generated on startup using :code:`uuid.uuid4()`"""
 
-    info_text = 'an auto-generated UUID'
+    class_info = 'an auto-generated UUID'
 
     @property
     def default(self):
@@ -953,7 +976,7 @@ class File(Property):
       to **mode**.
     """
 
-    info_text = 'an open file or filename'
+    class_info = 'an open file or filename'
 
     def __init__(self, doc, mode=None, **kwargs):
         self.mode = mode
@@ -1028,9 +1051,10 @@ class File(Property):
             self.error(instance, value, extra='File is closed.')
         return value
 
+    @property
     def info(self):
         """Help text for the File property, including valid modes"""
-        info = '{}, valid modes include {}'.format(self.info_text,
+        info = '{}, valid modes include {}'.format(self.class_info,
                                                    self.valid_modes)
         return info
 

--- a/properties/basic.py
+++ b/properties/basic.py
@@ -45,7 +45,7 @@ class GettableProperty(with_metaclass(ArgumentWrangler, object)):              #
     _class_default = undefined
 
     def __init__(self, doc, **kwargs):
-        self._base_doc = doc
+        self.doc = doc
         self._meta = {}
         for key in kwargs:
             if key[0] == '_':
@@ -62,6 +62,17 @@ class GettableProperty(with_metaclass(ArgumentWrangler, object)):              #
                 raise AttributeError(
                     'Cannot set property: "{}".'.format(key)
                 )
+
+    @property
+    def doc(self):
+        """Get the doc documentation of a Property instance"""
+        return self._doc
+
+    @doc.setter
+    def doc(self, value):
+        if not isinstance(value, string_types):
+            raise TypeError('doc must be a string')
+        self._doc = value
 
     @property
     def terms(self):
@@ -121,13 +132,6 @@ class GettableProperty(with_metaclass(ArgumentWrangler, object)):              #
         if not callable(value):
             raise TypeError('deserializer must be a callable')
         self._deserializer = value
-
-    @property
-    def doc(self):
-        """Get the doc documentation of a Property instance"""
-        if getattr(self, '_doc', None) is None:
-            self._doc = self._base_doc
-        return self._doc
 
     @property
     def meta(self):

--- a/properties/images.py
+++ b/properties/images.py
@@ -24,7 +24,7 @@ class ImagePNG(Property):
     * **filename** - name associated with open copy of PNG image
       (default is 'texture.png')
     """
-    info_text = 'a PNG image file'
+    class_info = 'a PNG image file'
 
     @property
     def filename(self):

--- a/properties/math.py
+++ b/properties/math.py
@@ -31,7 +31,7 @@ class Array(Property):
       Default: (float, int)
     """
 
-    info_text = 'a list or numpy array'
+    class_info = 'a list or numpy array'
 
     @property
     def wrapper(self):
@@ -84,9 +84,10 @@ class Array(Property):
                             'and/or bool'.format(value))
         self._dtype = value
 
+    @property
     def info(self):
         return '{info} of {type} with shape {shp}'.format(
-            info=self.info_text,
+            info=self.class_info,
             type=', '.join([str(t) for t in self.dtype]),
             shp='(' + ', '.join(['\*' if s == '*' else str(s)                  #pylint: disable=anomalous-backslash-in-string
                                  for s in self.shape]) + ')',
@@ -131,7 +132,7 @@ class Array(Property):
             "{desc} was specified. {extra}".format(
                 name=self.name,
                 cls=instance.__class__.__name__,
-                info=self.info(),
+                info=self.info,
                 desc=val_description,
                 extra=extra,
             )
@@ -217,7 +218,7 @@ class BaseVector(Array):
 class Vector3(BaseVector):
     """3D vector property"""
 
-    info_text = 'a 3D Vector'
+    class_info = 'a 3D Vector'
 
     @property
     def wrapper(self):
@@ -251,7 +252,7 @@ class Vector3(BaseVector):
 class Vector2(BaseVector):
     """2D vector property"""
 
-    info_text = 'a 2D Vector'
+    class_info = 'a 2D Vector'
 
     @property
     def wrapper(self):
@@ -288,7 +289,7 @@ class Vector2(BaseVector):
 class Vector3Array(BaseVector):
     """3D vector array property"""
 
-    info_text = 'a list of Vector3'
+    class_info = 'a list of Vector3'
 
     @property
     def wrapper(self):
@@ -328,7 +329,7 @@ class Vector3Array(BaseVector):
 class Vector2Array(BaseVector):
     """2D vector array property"""
 
-    info_text = 'a list of Vector2'
+    class_info = 'a list of Vector2'
 
     @property
     def wrapper(self):

--- a/properties/math.py
+++ b/properties/math.py
@@ -127,11 +127,17 @@ class Array(Property):
                 shp=value.shape,
                 typ=value.dtype
             )
-        raise error(
-            "The '{name}' property of a {cls} instance must be {info}. "
-            "{desc} was specified. {extra}".format(
+
+        if instance is None:
+            prefix = '{} property'.format(self.__class__.__name__)
+        else:
+            prefix = "The '{name}' property of a {cls} instance".format(
                 name=self.name,
                 cls=instance.__class__.__name__,
+            )
+        raise error(
+            '{prefix} must be {info}. {desc} was specified. {extra}'.format(
+                prefix=prefix,
                 info=self.info,
                 desc=val_description,
                 extra=extra,

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -9,6 +9,7 @@ import io
 import os
 import unittest
 import uuid
+import warnings
 
 import numpy as np
 import properties
@@ -473,6 +474,24 @@ class TestBasic(unittest.TestCase):
         assert myint.meta == {'first': 1, 'second': 2, 'third': 3}
 
         assert myint.terms.meta == myint.meta
+
+    def test_backwards_compat(self):
+
+        with warnings.catch_warnings(record=True) as w:
+
+            class NewProperty(properties.Property):
+                info_text = 'new property'
+
+                def info(self):
+                    return self.info_text
+
+            assert len(w) == 2
+            assert issubclass(w[0].category, FutureWarning)
+
+            np = NewProperty('')
+
+            assert getattr(np, 'class_info', None) == 'new property'
+            assert getattr(np, 'info', None) == 'new property'
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
1. The biggest change in this PR is renaming `info_text` to `class_info` and making `info` a property rather than a method. Both `info_text` and `info()` were directly copied from traitlets, and I think the former is not descriptive and the latter has no reason to not be a property. This change was made in a backwards compatible way so `Property` classes defined the old way will still be fine and just raise a warning. This change will have a minor effect on SimPEG. (see #104)

2. Error messages have been improved when `instance is None`. (see #98)

3. Property attributes have all been moved to property getters/setters. Most were this way, but some (eg `Union` `props`, `Instance` `instance_class`, etc) were not. (see #115)

4. `Instance` properties now support old-style classes (ie classes that are `types.ClassType`, not `type`).

@bsmithyman, @rowanc1 - I think 2, 3, 4 are safe, but I'm interested in feedback for 1. I think this change is worth it. Less ambiguity about what the different `info`s are and how to use them, but do you disagree? Is `class_info` ok?