### PR TITLE
regexp attribute for String properties

### DIFF
--- a/properties/basic.py
+++ b/properties/basic.py
@@ -791,6 +791,13 @@ class String(Property):
             value = value_type(value)
         return value
 
+    @property
+    def info(self):
+        info = 'a unicode string' if self.unicode else 'a string'
+        if self.regex is not None and hasattr(self.regex, 'pattern'):
+            info += ' that matches pattern "{}"'.format(self.regex.pattern)    #pylint: disable=no-member
+        return info
+
 
 class StringChoice(Property):
     """String property where only certain choices are allowed

--- a/properties/basic.py
+++ b/properties/basic.py
@@ -715,7 +715,7 @@ class String(Property):
       to ensure consistent behaviour across Python 2/3.
 
     * **regex** - regular expression (pattern or compiled expression) the
-      input string must include. Note: `search` is used to determine if
+      input string must match. Note: `search` is used to determine if
       string is valid; to match the entire string, ensure '^' and '$' are
       contained in the regex pattern.
     """
@@ -762,7 +762,7 @@ class String(Property):
 
     @property
     def regex(self):
-        """Regular expression the string must include"""
+        """Regular expression the string must match"""
         return getattr(self, '_regex', None)
 
     @regex.setter
@@ -800,7 +800,7 @@ class String(Property):
     def info(self):
         info = 'a unicode string' if self.unicode else 'a string'
         if self.regex is not None:
-            info += ' that contains pattern'
+            info += ' that matches pattern'
         if hasattr(self.regex, 'pattern'):
             info += ' "{}"'.format(self.regex.pattern)                         #pylint: disable=no-member
         return info

--- a/properties/basic.py
+++ b/properties/basic.py
@@ -778,7 +778,7 @@ class String(Property):
         value_type = type(value)
         if not isinstance(value, string_types):
             self.error(instance, value)
-        if self.regex is not None and self.regex.match(value) is None:
+        if self.regex is not None and self.regex.match(value) is None:         #pylint: disable=no-member
             self.error(instance, value)
         value = value.strip(self.strip)
         if self.change_case == 'upper':

--- a/properties/basic.py
+++ b/properties/basic.py
@@ -8,6 +8,7 @@ import collections
 import datetime
 import math
 import random
+import re
 import uuid
 from warnings import warn
 
@@ -712,6 +713,8 @@ class String(Property):
 
     * **unicode** - if True, coerce strings to unicode. Default is True
       to ensure consistent behaviour across Python 2/3.
+
+
     """
 
     class_info = 'a string'
@@ -754,10 +757,25 @@ class String(Property):
             raise TypeError("'unicode' property must be a boolean")
         self._unicode = value
 
+    @property
+    def regexp(self):
+        """Regular expression the string must comply with"""
+        return getattr(self, '_regexp', None)
+
+    @regexp.setter
+    def regexp(self, value):
+        if not isinstance(value, string_types):
+            raise TypeError("'regexp' must be a string")
+        self._regexp = value
+
     def validate(self, instance, value):
         """Check if value is a string, and strips it and changes case"""
         value_type = type(value)
         if not isinstance(value, string_types):
+            self.error(instance, value)
+        if self.regexp is None:
+            pass
+        elif re.match(self.regexp, value) is None:
             self.error(instance, value)
         value = value.strip(self.strip)
         if self.change_case == 'upper':

--- a/properties/basic.py
+++ b/properties/basic.py
@@ -766,7 +766,10 @@ class String(Property):
     @regex.setter
     def regex(self, value):
         if isinstance(value, string_types):
-            value = re.compile(value)
+            try:
+                value = re.compile(value)
+            except re.error:
+                raise TypeError('Invalid regex pattern: {}'.format(value))
         if hasattr(value, 'match') and callable(value.match):
             self._regex = value
         else:

--- a/properties/basic.py
+++ b/properties/basic.py
@@ -766,6 +766,10 @@ class String(Property):
     def regexp(self, value):
         if not isinstance(value, string_types):
             raise TypeError("'regexp' must be a string")
+        try:
+            self._regexp_compiled = re.compile(value)
+        except re.error:
+            raise ValueError("'regexp' is not valid")
         self._regexp = value
 
     def validate(self, instance, value):
@@ -773,9 +777,8 @@ class String(Property):
         value_type = type(value)
         if not isinstance(value, string_types):
             self.error(instance, value)
-        if self.regexp is None:
-            pass
-        elif re.match(self.regexp, value) is None:
+        if (self.regexp is not None and
+                self._regexp_compiled.match(value) is None):
             self.error(instance, value)
         value = value.strip(self.strip)
         if self.change_case == 'upper':

--- a/properties/basic.py
+++ b/properties/basic.py
@@ -714,7 +714,7 @@ class String(Property):
     * **unicode** - if True, coerce strings to unicode. Default is True
       to ensure consistent behaviour across Python 2/3.
 
-
+    * **regexp** - regular expression input string must comply with.
     """
 
     class_info = 'a string'

--- a/properties/basic.py
+++ b/properties/basic.py
@@ -714,7 +714,7 @@ class String(Property):
     * **unicode** - if True, coerce strings to unicode. Default is True
       to ensure consistent behaviour across Python 2/3.
 
-    * **regexp** - regular expression input string must comply with.
+    * **regex** - regular expression input string must comply with.
     """
 
     class_info = 'a string'
@@ -758,27 +758,27 @@ class String(Property):
         self._unicode = value
 
     @property
-    def regexp(self):
+    def regex(self):
         """Regular expression the string must comply with"""
-        return getattr(self, '_regexp', None)
+        return getattr(self, '_regex', None)
 
-    @regexp.setter
-    def regexp(self, value):
+    @regex.setter
+    def regex(self, value):
         if not isinstance(value, string_types):
-            raise TypeError("'regexp' must be a string")
+            raise TypeError("'regex' must be a string")
         try:
-            self._regexp_compiled = re.compile(value)
+            self._regex_compiled = re.compile(value)
         except re.error:
-            raise ValueError("'regexp' is not valid")
-        self._regexp = value
+            raise ValueError("'regex' is not valid")
+        self._regex = value
 
     def validate(self, instance, value):
         """Check if value is a string, and strips it and changes case"""
         value_type = type(value)
         if not isinstance(value, string_types):
             self.error(instance, value)
-        if (self.regexp is not None and
-                self._regexp_compiled.match(value) is None):
+        if (self.regex is not None and
+                self._regex_compiled.match(value) is None):
             self.error(instance, value)
         value = value.strip(self.strip)
         if self.change_case == 'upper':

--- a/properties/basic.py
+++ b/properties/basic.py
@@ -715,7 +715,9 @@ class String(Property):
       to ensure consistent behaviour across Python 2/3.
 
     * **regex** - regular expression (pattern or compiled expression) the
-      input string must comply with.
+      input string must include. Note: `search` is used to determine if
+      string is valid; to match the entire string, ensure '^' and '$' are
+      contained in the regex pattern.
     """
 
     class_info = 'a string'
@@ -760,7 +762,7 @@ class String(Property):
 
     @property
     def regex(self):
-        """Regular expression the string must comply with"""
+        """Regular expression the string must include"""
         return getattr(self, '_regex', None)
 
     @regex.setter
@@ -770,7 +772,7 @@ class String(Property):
                 value = re.compile(value)
             except re.error:
                 raise TypeError('Invalid regex pattern: {}'.format(value))
-        if hasattr(value, 'match') and callable(value.match):
+        if hasattr(value, 'search') and callable(value.search):
             self._regex = value
         else:
             raise TypeError("'regex' must be a string pattern or a compiled"
@@ -781,7 +783,7 @@ class String(Property):
         value_type = type(value)
         if not isinstance(value, string_types):
             self.error(instance, value)
-        if self.regex is not None and self.regex.match(value) is None:         #pylint: disable=no-member
+        if self.regex is not None and self.regex.search(value) is None:        #pylint: disable=no-member
             self.error(instance, value)
         value = value.strip(self.strip)
         if self.change_case == 'upper':
@@ -797,8 +799,10 @@ class String(Property):
     @property
     def info(self):
         info = 'a unicode string' if self.unicode else 'a string'
-        if self.regex is not None and hasattr(self.regex, 'pattern'):
-            info += ' that matches pattern "{}"'.format(self.regex.pattern)    #pylint: disable=no-member
+        if self.regex is not None:
+            info += ' that contains pattern'
+        if hasattr(self.regex, 'pattern'):
+            info += ' "{}"'.format(self.regex.pattern)                         #pylint: disable=no-member
         return info
 
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -7,6 +7,7 @@ from __future__ import unicode_literals
 import datetime
 import io
 import os
+import re
 import unittest
 import uuid
 import warnings
@@ -265,12 +266,18 @@ class TestBasic(unittest.TestCase):
 
         class StringOpts(properties.HasProperties):
             mystring = properties.String('email', regex=r'.+\@.+\..+')
+            anotherstring = properties.String('one character',
+                                              regex=re.compile(r'^.$'))
 
         strings = StringOpts()
         strings.mystring = 'test@test.com'
+        strings.anotherstring = 'a'
 
         with self.assertRaises(ValueError):
             strings.mystring = 'not an email'
+
+        with self.assertRaises(ValueError):
+            strings.anotherstring = 'aa'
 
     def test_string_choice(self):
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -214,7 +214,7 @@ class TestBasic(unittest.TestCase):
         with self.assertRaises(TypeError):
             properties.String('bad unicode', unicode='no')
         with self.assertRaises(TypeError):
-            properties.String('bad regexp', regexp=5)
+            properties.String('bad regex', regex=5)
 
         class StringOpts(properties.HasProperties):
             mystring = properties.String('My string')
@@ -264,7 +264,7 @@ class TestBasic(unittest.TestCase):
         assert isinstance(strings.mystring, six.text_type)
 
         class StringOpts(properties.HasProperties):
-            mystring = properties.String('email', regexp=r'.+\@.+\..+')
+            mystring = properties.String('email', regex=r'.+\@.+\..+')
 
         strings = StringOpts()
         strings.mystring = 'test@test.com'

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -213,6 +213,8 @@ class TestBasic(unittest.TestCase):
             properties.String('bad case', change_case='mixed')
         with self.assertRaises(TypeError):
             properties.String('bad unicode', unicode='no')
+        with self.assertRaises(TypeError):
+            properties.String('bad regexp', regexp=5)
 
         class StringOpts(properties.HasProperties):
             mystring = properties.String('My string')
@@ -260,6 +262,15 @@ class TestBasic(unittest.TestCase):
         assert isinstance(strings.mystring, str)
         strings.mystring = u'hi'
         assert isinstance(strings.mystring, six.text_type)
+
+        class StringOpts(properties.HasProperties):
+            mystring = properties.String('email', regexp=r'.+\@.+\..+')
+
+        strings = StringOpts()
+        strings.mystring = 'test@test.com'
+
+        with self.assertRaises(ValueError):
+            strings.mystring = 'not an email'
 
     def test_string_choice(self):
 


### PR DESCRIPTION
Add regular expression attribute strings must comply with. If `None` (default), any string is accepted.