### PR TITLE
Add `descriptions` attribute to StringChoice

### DIFF
--- a/properties/basic.py
+++ b/properties/basic.py
@@ -852,7 +852,7 @@ class StringChoice(Property):
         return self._choices
 
     @choices.setter
-    def choices(self, value):
+    def choices(self, value):                                                  #pylint: disable=too-many-branches
         if isinstance(value, (set, list, tuple)):
             if len(value) != len(set(value)):
                 raise TypeError("'choices' must contain no duplicate strings")

--- a/properties/basic.py
+++ b/properties/basic.py
@@ -815,7 +815,7 @@ class StringChoice(Property):
       OR a dictionary of string key and list-of-string value pairs,
       where any string in the value list is coerced into the key string.
     * **descriptions** - dictionary of choice/description key/value
-      pairs. Must contain all choices
+      pairs. Must contain all choices.
     """
 
     class_info = 'a string choice'
@@ -840,14 +840,14 @@ class StringChoice(Property):
         or (2) a dictionary of string key and list-of-string value pairs,
         where any string in the value list is coerced into the key string.
         """
-        return getattr(self, '_choices', {})
+        return self._choices
 
     @choices.setter
     def choices(self, value):
         if isinstance(value, (set, list, tuple)):
             if len(value) != len(set(value)):
                 raise TypeError("'choices' must contain no duplicate strings")
-            value = {v: [] for v in value}
+            value = collections.OrderedDict((v, []) for v in value)
         if not isinstance(value, dict):
             raise TypeError("'choices' must be a set, list, tuple, or dict")
         for key, val in value.items():

--- a/properties/basic.py
+++ b/properties/basic.py
@@ -863,7 +863,7 @@ class StringChoice(Property):
                 if not isinstance(sub_val, string_types):
                     raise TypeError("'choices' must be strings")
             all_items += [key] + val
-        if len(all_items) != len(set(all_items)):
+        if len(all_items) != len(set(item.upper() for item in all_items)):
             raise TypeError("'choices' must contain no duplicate strings")
         self._choices = value
 

--- a/properties/basic.py
+++ b/properties/basic.py
@@ -814,6 +814,8 @@ class StringChoice(Property):
     * **choices** - either a list/tuple of allowed strings
       OR a dictionary of string key and list-of-string value pairs,
       where any string in the value list is coerced into the key string.
+    * **descriptions** - dictionary of choice/description key/value
+      pairs. Must contain all choices
     """
 
     class_info = 'a string choice'
@@ -864,6 +866,28 @@ class StringChoice(Property):
         if len(all_items) != len(set(all_items)):
             raise TypeError("'choices' must contain no duplicate strings")
         self._choices = value
+
+    @property
+    def descriptions(self):
+        """Dictionary of descriptions for available choices
+
+        Keys must correspond to all choices and values must be string
+        descriptions
+        """
+        return getattr(self, '_descriptions', None)
+
+    @descriptions.setter
+    def descriptions(self, value):
+        if not isinstance(value, dict):
+            raise TypeError("'descriptions' must be a dictionary")
+        if len(value) != len(self.choices):
+            raise TypeError("'descriptions' must contain all choices as keys")
+        for key, val in value.items():
+            if key not in self.choices:
+                raise TypeError("'descriptions' keys must be valid choices")
+            if not isinstance(val, string_types):
+                raise TypeError("'descriptions' values must be strings")
+        self._descriptions = value
 
     def validate(self, instance, value):
         """Check if input is a valid string based on the choices"""

--- a/properties/basic.py
+++ b/properties/basic.py
@@ -827,10 +827,16 @@ class StringChoice(Property):
     @property
     def info(self):
         """Formatted string to display the available choices"""
+        if self.descriptions is None:
+            choice_list = ['"{}"'.format(choice) for choice in self.choices]
+        else:
+            choice_list = [
+                '"{}" ({})'.format(choice, self.descriptions[choice])
+                for choice in self.choices
+            ]
         if len(self.choices) == 2:
-            return 'either "{}" or "{}"'.format(list(self.choices)[0],
-                                                list(self.choices)[1])
-        return 'any of "{}"'.format('", "'.join(self.choices))
+            return 'either {} or {}'.format(choice_list[0], choice_list[1])
+        return 'any of {}'.format(', '.join(choice_list))
 
     @property
     def choices(self):

--- a/properties/task/image.py
+++ b/properties/task/image.py
@@ -58,7 +58,8 @@ class PlotImagePNG(Task):                                                      #
     )
     cmap = StringChoice(
         'Selected color map',
-        list({key.upper(): key for key in cm.cmap_d.keys()}.values()),
+        list(cm.cmap_d.keys()),
+        case_sensitive=True,
         default='jet',
     )
     aspect = Union(

--- a/properties/task/image.py
+++ b/properties/task/image.py
@@ -58,7 +58,7 @@ class PlotImagePNG(Task):                                                      #
     )
     cmap = StringChoice(
         'Selected color map',
-        list(cm.cmap_d.keys()),
+        list({key.upper(): key for key in cm.cmap_d.keys()}.values()),
         default='jet',
     )
     aspect = Union(

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -294,6 +294,18 @@ class TestBasic(unittest.TestCase):
         with self.assertRaises(TypeError):
             properties.StringChoice('bad choices', [5, 6, 7])
 
+        choiceprop = properties.StringChoice('good choices', ['a', 'b', 'c'])
+        with self.assertRaises(TypeError):
+            choiceprop.descriptions = ['letter a', 'letter b', 'letter c']
+        with self.assertRaises(TypeError):
+            choiceprop.descriptions = {'a': 'letter a', 'b': 'letter b'}
+        with self.assertRaises(TypeError):
+            choiceprop.descriptions = {'a': 'letter a',
+                                       'b': 'letter b',
+                                       'd': 'letter d'}
+        with self.assertRaises(TypeError):
+            choiceprop.descriptions = {'a': 1, 'b': 2, 'c': 3}
+
         class StrChoicesOpts(properties.HasProperties):
             mychoicelist = properties.StringChoice(
                 'list of choices', ['a', 'e', 'i', 'o', 'u']
@@ -306,7 +318,12 @@ class TestBasic(unittest.TestCase):
                 'tuple of choices', ('a', 'e', 'i', 'o', 'u')
             )
             mychoiceset = properties.StringChoice(
-                'set of choices', {'a', 'e', 'i', 'o', 'u'}
+                'set of choices', {'a', 'e', 'i', 'o', 'u'},
+                descriptions={'a': 'The first letter of the alphabet',
+                              'e': 'A really great vowel',
+                              'i': 'This letter is also a word!',
+                              'o': 'Another excellent vowel',
+                              'u': 'Less useful vowel'}
             )
 
         choices = StrChoicesOpts()

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -306,6 +306,13 @@ class TestBasic(unittest.TestCase):
         with self.assertRaises(TypeError):
             choiceprop.descriptions = {'a': 1, 'b': 2, 'c': 3}
 
+        with self.assertRaises(TypeError):
+            properties.StringChoice('bad case', ['a', 'b'], 5)
+        with self.assertRaises(TypeError):
+            properties.StringChoice('bad case', ['a', 'A'])
+        with self.assertRaises(TypeError):
+            properties.StringChoice('bad case', ['a', 'a'], True)
+
         class StrChoicesOpts(properties.HasProperties):
             mychoicelist = properties.StringChoice(
                 'list of choices', ['a', 'e', 'i', 'o', 'u']
@@ -325,6 +332,9 @@ class TestBasic(unittest.TestCase):
                               'o': 'Another excellent vowel',
                               'u': 'Less useful vowel'}
             )
+            mysensitive = properties.StringChoice(
+                'bad case', ['a', 'A', 'b'], True
+            )
 
         choices = StrChoicesOpts()
 
@@ -332,8 +342,10 @@ class TestBasic(unittest.TestCase):
             choices.mychoicelist = 'k'
         with self.assertRaises(ValueError):
             choices.mychoicelist = 5
+        with self.assertRaises(ValueError):
+            choices.mysensitive = 'B'
 
-        choices.mychoicelist = 'o'
+        choices.mychoicelist = 'O'
         choices.mychoicedict = 'e'
         assert choices.mychoicedict == 'vowel'
         choices.mychoicedict = 'maybe'


### PR DESCRIPTION
As discussed in #103 

This also cleans up a few other things in StringChoice:
- `choices` order is preserved if possible using `OrderedDict`
- if `_choices` is somehow deleted, accessing `choices` will error, rather than default to `{}`
- make `choices` duplicate check case-insensitive ~since validation is case-insensitive~ unless new `case_sensitive` attribute is `True`.