### PR TITLE
Fix infinite recursion problems with validation/serialization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ python:
   - 3.6
 sudo: false
 
+matrix:
+  allow_failures:
+    - python: 3.6
+
 addons:
   apt:
     packages:

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 3point Science
+Copyright (c) 2017 3point Science
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -58,7 +58,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'properties'
-copyright = u'2016, 3point Science'
+copyright = u'2017, 3point Science'
 author = u'3point Science'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/properties/__init__.py
+++ b/properties/__init__.py
@@ -68,4 +68,4 @@ from .handlers import observer, validator
 __version__ = '0.3.0'
 __author__ = '3point Science'
 __license__ = 'MIT'
-__copyright__ = 'Copyright 2016 3point Science,'
+__copyright__ = 'Copyright 2017 3point Science,'

--- a/properties/__init__.py
+++ b/properties/__init__.py
@@ -62,7 +62,7 @@ try:
 except ImportError:
     pass
 
-from .utils import everything, undefined, filter_props, RecursionError
+from .utils import everything, undefined, filter_props, SelfReferenceError
 from .handlers import observer, validator
 
 __version__ = '0.3.0'

--- a/properties/__init__.py
+++ b/properties/__init__.py
@@ -62,7 +62,7 @@ try:
 except ImportError:
     pass
 
-from .utils import everything, undefined, filter_props
+from .utils import everything, undefined, filter_props, RecursionError
 from .handlers import observer, validator
 
 __version__ = '0.3.0'

--- a/properties/base.py
+++ b/properties/base.py
@@ -404,6 +404,7 @@ class Instance(basic.Property):
             value.validate()
         return True
 
+    @utils.stop_recursion_with('Not serialized to prevent infinite recursion')
     def serialize(self, value, include_class=True, **kwargs):
         """Serialize instance to JSON
 

--- a/properties/base.py
+++ b/properties/base.py
@@ -268,15 +268,12 @@ class HasProperties(with_metaclass(PropertyMetaclass, object)):
         return True
 
     @handlers.validator
+    @utils.stop_recursion_with(True)
     def _validate_props(self):
         """Assert that all the properties are valid on validate()"""
-        self._validating = True
-        try:
-            for k in self._props:
-                prop = self._props[k]
-                prop.assert_valid(self)
-        finally:
-            self._validating = False
+        for k in self._props:
+            prop = self._props[k]
+            prop.assert_valid(self)
         return True
 
     def serialize(self, include_class=True, **kwargs):

--- a/properties/base.py
+++ b/properties/base.py
@@ -276,6 +276,10 @@ class HasProperties(with_metaclass(PropertyMetaclass, object)):
             prop.assert_valid(self)
         return True
 
+    @utils.stop_recursion_with(
+        lambda self, *_, **__:
+        '(Already serialized instance of {})'.format(self.__class__.__name__)
+    )
     def serialize(self, include_class=True, **kwargs):
         """Serializes a HasProperties instance to JSON"""
         data = ((k, v.serialize(self._get(v.name), include_class, **kwargs))
@@ -404,7 +408,6 @@ class Instance(basic.Property):
             value.validate()
         return True
 
-    @utils.stop_recursion_with('Not serialized to prevent infinite recursion')
     def serialize(self, value, include_class=True, **kwargs):
         """Serialize instance to JSON
 

--- a/properties/base.py
+++ b/properties/base.py
@@ -277,8 +277,7 @@ class HasProperties(with_metaclass(PropertyMetaclass, object)):
         return True
 
     @utils.stop_recursion_with(
-        lambda self, *_, **__:
-        '(Already serialized instance of {})'.format(self.__class__.__name__)
+        utils.RecursionError('Object contains unserializable self reference')
     )
     def serialize(self, include_class=True, **kwargs):
         """Serializes a HasProperties instance to JSON"""
@@ -320,6 +319,9 @@ class HasProperties(with_metaclass(PropertyMetaclass, object)):
         for key, val in iteritems(newstate):
             setattr(self, key, pickle.loads(val))
 
+    @utils.stop_recursion_with(
+        utils.RecursionError('Object contains unpicklable self reference')
+    )
     def __reduce__(self):
         data = ((k, self._get(v.name)) for k, v in iteritems(self._props))
         pickle_dict = {k: pickle.dumps(v) for k, v in data if v is not None}

--- a/properties/base.py
+++ b/properties/base.py
@@ -277,7 +277,7 @@ class HasProperties(with_metaclass(PropertyMetaclass, object)):
         return True
 
     @utils.stop_recursion_with(
-        utils.RecursionError('Object contains unserializable self reference')
+        utils.SelfReferenceError('Object contains unserializable self reference')
     )
     def serialize(self, include_class=True, **kwargs):
         """Serializes a HasProperties instance to JSON"""
@@ -320,7 +320,7 @@ class HasProperties(with_metaclass(PropertyMetaclass, object)):
             setattr(self, key, pickle.loads(val))
 
     @utils.stop_recursion_with(
-        utils.RecursionError('Object contains unpicklable self reference')
+        utils.SelfReferenceError('Object contains unpicklable self reference')
     )
     def __reduce__(self):
         data = ((k, self._get(v.name)) for k, v in iteritems(self._props))

--- a/properties/base.py
+++ b/properties/base.py
@@ -396,10 +396,10 @@ class Instance(basic.Property):
     def assert_valid(self, instance, value=None):
         """Checks if valid, including HasProperty instances pass validation"""
         valid = super(Instance, self).assert_valid(instance, value)
-        if valid is False:
-            return valid
+        if not valid:
+            return False
         if value is None:
-            value = getattr(instance, self.name, None)
+            value = instance._get(self.name)
         if isinstance(value, HasProperties):
             value.validate()
         return True
@@ -581,10 +581,10 @@ class List(basic.Property):
     def assert_valid(self, instance, value=None):
         """Check if list and contained properties are valid"""
         valid = super(List, self).assert_valid(instance, value)
-        if valid is False:
-            return valid
+        if not valid:
+            return False
         if value is None:
-            value = getattr(instance, self.name, None)
+            value = instance._get(self.name)
         if value is None:
             return True
         if self.min_length is not None and len(value) < self.min_length:
@@ -744,8 +744,8 @@ class Union(basic.Property):
     def assert_valid(self, instance, value=None):
         """Check if the Union has a valid value"""
         valid = super(Union, self).assert_valid(instance, value)
-        if valid is False:
-            return valid
+        if not valid:
+            return False
         for prop in self.props:
             try:
                 return prop.assert_valid(instance, value)

--- a/properties/basic.py
+++ b/properties/basic.py
@@ -182,7 +182,7 @@ class GettableProperty(with_metaclass(ArgumentWrangler, object)):              #
     def assert_valid(self, instance, value=None):
         """Check if the current state of a property is valid"""
         if value is None:
-            value = getattr(instance, self.name, None)
+            value = instance._get(self.name)
         if value is not None:
             self.validate(instance, value)
         return True
@@ -457,7 +457,7 @@ class Property(GettableProperty):
     def assert_valid(self, instance, value=None):
         """Check if required properties are set and ensure value is valid"""
         if value is None:
-            value = getattr(instance, self.name, None)
+            value = instance._get(self.name)
         if value is None and self.required:
             raise ValueError(
                 "The '{name}' property of a {cls} instance is required "
@@ -1033,7 +1033,7 @@ class Uuid(GettableProperty):
     def assert_valid(self, instance, value=None):
         """Ensure the value is a UUID instance"""
         if value is None:
-            value = getattr(instance, self.name, None)
+            value = instance._get(self.name)
         if not isinstance(value, uuid.UUID) or not value.version == 4:
             raise ValueError(
                 "The '{name}' property of a {cls} instance must be a unique "

--- a/properties/utils.py
+++ b/properties/utils.py
@@ -84,17 +84,24 @@ class stop_recursion_with(object):                                             #
             """
             if self in decorator.held_objects:
                 if callable(decorator.backup):
-                    return decorator.backup(self, *args, **kwargs)
-                return decorator.backup
+                    output = decorator.backup(self, *args, **kwargs)
+                output = decorator.backup
+                if isinstance(output, Exception):
+                    raise output
+                return output
             else:
                 try:
                     decorator.held_objects.add(self)
-                    func_output = func(self, *args, **kwargs)
+                    output = func(self, *args, **kwargs)
                 finally:
                     decorator.held_objects.remove(self)
-                return func_output
+                return output
 
         return run_once
+
+
+class RecursionError(Exception):
+    """Exception type to be raised with infinite recursion problems"""
 
 
 class Sentinel(object):                                                        #pylint: disable=too-few-public-methods

--- a/properties/utils.py
+++ b/properties/utils.py
@@ -53,8 +53,7 @@ def stop_recursion_with(backup_return_value):
                 finally:
                     setattr(self, placeholder, False)
                 return first_return_value
-        # run_once.__name__ = func.__name__
-        # run_once.__doc__ = func.__doc__
+
         return run_once
     return wrapper
 

--- a/properties/utils.py
+++ b/properties/utils.py
@@ -100,7 +100,7 @@ class stop_recursion_with(object):                                             #
         return run_once
 
 
-class RecursionError(Exception):
+class SelfReferenceError(Exception):
     """Exception type to be raised with infinite recursion problems"""
 
 

--- a/tests/test_recursion.py
+++ b/tests/test_recursion.py
@@ -63,10 +63,10 @@ class TestRecursion(unittest.TestCase):
         with self.assertRaises(ValueError):
             hhpl.validate()
 
-        with self.assertRaises(properties.RecursionError):
+        with self.assertRaises(properties.SelfReferenceError):
             hhpl.serialize()
 
-        with self.assertRaises(properties.RecursionError):
+        with self.assertRaises(properties.SelfReferenceError):
             pickle.dumps(hhpl)
 
 

--- a/tests/test_recursion.py
+++ b/tests/test_recursion.py
@@ -1,0 +1,69 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import unittest
+
+import properties
+
+
+class TestRecursion(unittest.TestCase):
+
+    def test_basic_recursion(self):
+
+        class HasHasProps(properties.HasProperties):
+            my_hp = properties.Instance('dangerous', properties.HasProperties)
+            my_int = properties.Integer('an int')
+
+        hhp = HasHasProps(my_int=5)
+        with self.assertRaises(ValueError):
+            hhp.validate()
+
+        hhp.my_hp = hhp
+
+        hhp.validate()
+
+        hhp.my_int = properties.undefined
+
+        with self.assertRaises(ValueError):
+            hhp.validate()
+
+    def test_list_recursion(self):
+
+        class HasInteger(properties.HasProperties):
+            my_int = properties.Integer('an int')
+
+        class HasHasProps(properties.HasProperties):
+            my_hp = properties.Instance('dangerous', properties.HasProperties)
+
+        class HasHasPropsList(properties.HasProperties):
+            my_list = properties.List('dangerous', properties.HasProperties)
+
+        hi_valid = HasInteger(my_int=5)
+        hi_invalid = HasInteger()
+        hhp = HasHasProps()
+        hhpl = HasHasPropsList()
+
+        hhp.my_hp = hi_valid
+        hhp.validate()
+
+        hhpl.my_list = [hhp]
+        hhpl.validate()
+        hhpl.my_list += [hi_invalid]
+        with self.assertRaises(ValueError):
+            hhpl.validate()
+
+        hhpl.my_list[1] = hi_valid
+        hhpl.validate()
+        hhp.my_hp = hhpl
+        hhpl.validate()
+        hhpl.my_list += [hi_invalid]
+        with self.assertRaises(ValueError):
+            hhpl.validate()
+
+        hhpl.serialize()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_recursion.py
+++ b/tests/test_recursion.py
@@ -3,6 +3,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import pickle
 import unittest
 
 import properties
@@ -62,7 +63,11 @@ class TestRecursion(unittest.TestCase):
         with self.assertRaises(ValueError):
             hhpl.validate()
 
-        hhpl.serialize()
+        with self.assertRaises(properties.RecursionError):
+            hhpl.serialize()
+
+        with self.assertRaises(properties.RecursionError):
+            pickle.dumps(hhpl)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This creates a wrapper for functions that runs the function once and gives an alternative return value if the same function is called again recursively. This prevents infinite recursion during validation and serialization.