### PR TITLE
Implement `equal` method for properties

### DIFF
--- a/properties/__init__.py
+++ b/properties/__init__.py
@@ -62,8 +62,18 @@ try:
 except ImportError:
     pass
 
-from .handlers import listeners_disabled, observer, validator
-from .utils import everything, undefined, filter_props, SelfReferenceError
+from .handlers import (
+    listeners_disabled,
+    observer,
+    validator,
+)
+from .utils import (
+    everything,
+    filter_props,
+    SelfReferenceError,
+    stop_recursion_with,
+    undefined,
+)
 
 __version__ = '0.3.0'
 __author__ = '3point Science'

--- a/properties/base.py
+++ b/properties/base.py
@@ -339,8 +339,10 @@ class HasProperties(with_metaclass(PropertyMetaclass, object)):
         pickle_dict = {k: pickle.dumps(v) for k, v in data if v is not None}
         return (self.__class__, (), pickle_dict)
 
-    @utils.stop_recursion_with(True)
+    @utils.stop_recursion_with(False)
     def __eq__(self, other):
+        if self is other:
+            return True
         if not isinstance(other, self.__class__):
             return False
         for prop in itervalues(self._props):

--- a/properties/base.py
+++ b/properties/base.py
@@ -268,7 +268,17 @@ class HasProperties(with_metaclass(PropertyMetaclass, object)):
     @utils.stop_recursion_with(True)
     def _validate_props(self):
         """Assert that all the properties are valid on validate()"""
-        for prop in itervalues(self._props):
+        for key, prop in iteritems(self._props):
+            value = self._get(key)
+            if value is not None:
+                change = dict(name=key, value=self._get(key), mode='validate')
+                self._notify(change)
+                if not prop.equal(self._get(key), change['value']):
+                    raise ValueError(
+                        'Invalid value for property {}: {}'.format(
+                            key, self._get(key)
+                        )
+                    )
             prop.assert_valid(self)
         return True
 

--- a/properties/base.py
+++ b/properties/base.py
@@ -309,7 +309,7 @@ class HasProperties(with_metaclass(PropertyMetaclass, object)):
                         rcl=value['__class__'], cl=cls.__name__
                     ), RuntimeWarning
                 )
-        state, unused = utils.filter_props(cls, value, False)
+        state, unused = utils.filter_props(cls, value, True)
         unused.pop('__class__', None)
         if len(unused) > 0 and verbose:
             warn('Unused properties during deserialization: {}'.format(
@@ -318,7 +318,7 @@ class HasProperties(with_metaclass(PropertyMetaclass, object)):
         newstate = {}
         for key, val in iteritems(state):
             newstate[key] = cls._props[key].deserialize(val, trusted, **kwargs)
-        mutable, immutable = utils.filter_props(cls, newstate, True)
+        mutable, immutable = utils.filter_props(cls, newstate, False)
         with handlers.listeners_disabled():
             newinst = cls(**mutable)
         for key, val in iteritems(immutable):

--- a/properties/basic.py
+++ b/properties/basic.py
@@ -61,7 +61,6 @@ class GettableProperty(with_metaclass(ArgumentWrangler, object)):              #
     * **default** - property's default value
     """
     class_info = 'corrected'
-    name = ''
     _class_default = undefined
 
     def __init__(self, doc, **kwargs):

--- a/properties/basic.py
+++ b/properties/basic.py
@@ -84,6 +84,20 @@ class GettableProperty(with_metaclass(ArgumentWrangler, object)):              #
                 )
 
     @property
+    def name(self):
+        """The name of the property on a HasProperties class
+
+        This is set in the metaclass.
+        """
+        return getattr(self, '_name', '')
+
+    @name.setter
+    def name(self, value):
+        if not isinstance(value, string_types):
+            raise TypeError('name must be a string')
+        self._name = value
+
+    @property
     def doc(self):
         """Get the doc documentation of a Property instance"""
         return self._doc
@@ -360,6 +374,8 @@ class DynamicProperty(GettableProperty):                                       #
 
     @name.setter
     def name(self, value):
+        if not isinstance(value, string_types):
+            raise TypeError('name must be a string')
         self.prop.name = value
         self._name = value
 
@@ -442,6 +458,9 @@ class DynamicProperty(GettableProperty):                                       #
             scope.del_func(self)
 
         return property(fget=fget, fset=fset, fdel=fdel, doc=scope.doc)
+
+    def equal(self, value_a, value_b):
+        return self.prop.equal(value_a, value_b)
 
     def sphinx_class(self):
         """Property class name formatted for Sphinx doc linking"""
@@ -663,7 +682,7 @@ class Float(Integer):
 
     def equal(self, value_a, value_b):
         try:
-            return abs(value_a - value_b) < TOL
+            return abs(value_a - value_b) <= TOL
         except TypeError:
             return False
 
@@ -701,8 +720,8 @@ class Complex(Property):
 
     def equal(self, value_a, value_b):
         try:
-            real_equal = abs(value_a.real - value_b.real) > TOL
-            imag_equal = abs(value_a.imag - value_b.imag) > TOL
+            real_equal = abs(value_a.real - value_b.real) <= TOL
+            imag_equal = abs(value_a.imag - value_b.imag) <= TOL
             return real_equal and imag_equal
         except (TypeError, AttributeError):
             return False

--- a/properties/basic.py
+++ b/properties/basic.py
@@ -192,7 +192,7 @@ class GettableProperty(with_metaclass(ArgumentWrangler, object)):              #
             ))
         return True
 
-    def equal(self, value_a, value_b):
+    def equal(self, value_a, value_b):                                         #pylint: disable=no-self-use
         """Test if two property values are equal"""
         return value_a == value_b
 

--- a/properties/basic.py
+++ b/properties/basic.py
@@ -802,7 +802,7 @@ class String(Property):
         if isinstance(value, string_types):
             try:
                 value = re.compile(value)
-            except re.error:
+            except (re.error, TypeError):
                 raise TypeError('Invalid regex pattern: {}'.format(value))
         if hasattr(value, 'search') and callable(value.search):
             self._regex = value

--- a/properties/math.py
+++ b/properties/math.py
@@ -113,12 +113,14 @@ class Array(Property):
         return value
 
     def equal(self, value_a, value_b):
-        values_equal = (
-            isinstance(value_a, self.wrapper) and
-            isinstance(value_b, self.wrapper) and
-            np.allclose(value_a, value_b, atol=TOL, equal_nan=True)
-        )
-        return values_equal
+        if not isinstance(value_a, self.wrapper):
+            return False
+        if not isinstance(value_a, self.wrapper):
+            return False
+        nan_mask = ~np.isnan(value_a)
+        if not np.array_equal(nan_mask, ~np.isnan(value_b)):
+            return False
+        return np.allclose(value_a[nan_mask], value_b[nan_mask], atol=TOL)
 
 
     def error(self, instance, value, error=None, extra=''):

--- a/properties/math.py
+++ b/properties/math.py
@@ -8,7 +8,7 @@ import numpy as np
 from six import integer_types, string_types
 import vectormath as vmath
 
-from .basic import Property
+from .basic import Property, TOL
 
 TYPE_MAPPINGS = {
     int: 'i',
@@ -111,6 +111,15 @@ class Array(Property):
             if shp != '*' and value.shape[i] != shp:
                 self.error(instance, value)
         return value
+
+    def equal(self, value_a, value_b):
+        values_equal = (
+            isinstance(value_a, self.wrapper) and
+            isinstance(value_b, self.wrapper) and
+            np.allclose(value_a, value_b, atol=TOL, equal_nan=True)
+        )
+        return values_equal
+
 
     def error(self, instance, value, error=None, extra=''):
         """Generates a ValueError on setting property to an invalid value"""

--- a/properties/math.py
+++ b/properties/math.py
@@ -113,14 +113,15 @@ class Array(Property):
         return value
 
     def equal(self, value_a, value_b):
-        if not isinstance(value_a, self.wrapper):
+        try:
+            if value_a.__class__ is not value_b.__class__:
+                return False
+            nan_mask = ~np.isnan(value_a)
+            if not np.array_equal(nan_mask, ~np.isnan(value_b)):
+                return False
+            return np.allclose(value_a[nan_mask], value_b[nan_mask], atol=TOL)
+        except TypeError:
             return False
-        if not isinstance(value_a, self.wrapper):
-            return False
-        nan_mask = ~np.isnan(value_a)
-        if not np.array_equal(nan_mask, ~np.isnan(value_b)):
-            return False
-        return np.allclose(value_a[nan_mask], value_b[nan_mask], atol=TOL)
 
 
     def error(self, instance, value, error=None, extra=''):

--- a/properties/utils.py
+++ b/properties/utils.py
@@ -85,7 +85,8 @@ class stop_recursion_with(object):                                             #
             if self in decorator.held_objects:
                 if callable(decorator.backup):
                     output = decorator.backup(self, *args, **kwargs)
-                output = decorator.backup
+                else:
+                    output = decorator.backup
                 if isinstance(output, Exception):
                     raise output
                 return output

--- a/properties/utils.py
+++ b/properties/utils.py
@@ -70,7 +70,7 @@ class stop_recursion_with(object):                                             #
 
     def __init__(self, backup):
         self.backup = backup
-        self.held_objects = set()
+        self.held_objects = []
 
     def __call__(self, func):
         decorator = self
@@ -91,7 +91,7 @@ class stop_recursion_with(object):                                             #
                 return output
             else:
                 try:
-                    decorator.held_objects.add(self)
+                    decorator.held_objects.append(self)
                     output = func(self, *args, **kwargs)
                 finally:
                     decorator.held_objects.remove(self)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -105,6 +105,10 @@ class TestBasic(unittest.TestCase):
         opt.mybool = False
         assert opt.mybool is False
 
+        assert properties.Bool('').equal(True, True)
+        assert not properties.Bool('').equal(True, 1)
+        assert not properties.Bool('').equal(True, 'true')
+
         json = properties.Bool.to_json(opt.mybool)
         assert not json
         assert not properties.Bool.from_json(json)
@@ -125,6 +129,10 @@ class TestBasic(unittest.TestCase):
 
         assert BoolOpts.deserialize({'mybool': 'Y'}).mybool
         assert BoolOpts._props['mybool'].deserialize(None) is None
+
+        assert properties.Bool('').equal(True, True)
+        assert not properties.Bool('').equal(True, 1)
+        assert not properties.Bool('').equal(True, 'true')
 
     def test_numbers(self):
 
@@ -180,6 +188,10 @@ class TestBasic(unittest.TestCase):
         self.assertEqual(nums.serialize(include_class=False), serialized)
         assert NumOpts.deserialize(serialized).myfloatrange == 10.
 
+        assert properties.Integer('').equal(5, 5)
+        assert properties.Float('').equal(5, 5.)
+        assert not properties.Float('').equal(5, 5.1)
+
     def test_complex(self):
 
         class ComplexOpts(properties.HasProperties):
@@ -205,6 +217,9 @@ class TestBasic(unittest.TestCase):
         self.assertEqual(comp.serialize(include_class=False),
                          {'mycomplex': '(5+2j)'})
         assert ComplexOpts.deserialize({'mycomplex': '(0+1j)'}).mycomplex == 1j
+
+        assert properties.Complex('').equal((1+1j), (1+1j))
+        assert not properties.Complex('').equal((1+1j), 1)
 
     def test_string(self):
 
@@ -278,6 +293,9 @@ class TestBasic(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             strings.anotherstring = 'aa'
+
+        assert properties.String('').equal('equal', 'equal')
+        assert not properties.String('').equal('equal', 'EQUAL')
 
     def test_string_choice(self):
 
@@ -358,6 +376,9 @@ class TestBasic(unittest.TestCase):
             {'mychoicedict': 'a'}
         ).mychoicedict == 'vowel'
 
+        assert properties.StringChoice('', {}).equal('equal', 'equal')
+        assert not properties.StringChoice('', {}).equal('equal', 'EQUAL')
+
     def test_color(self):
 
         class ColorOpts(properties.HasProperties):
@@ -395,6 +416,9 @@ class TestBasic(unittest.TestCase):
             {'mycolor': [0, 10, 20]}
         ).mycolor == (0, 10, 20)
 
+        assert properties.Color('').equal((0, 10, 20), (0, 10, 20))
+        assert not properties.Color('').equal((0, 10, 20), [0, 10, 20])
+
     def test_datetime(self):
 
         class DateTimeOpts(properties.HasProperties):
@@ -422,6 +446,11 @@ class TestBasic(unittest.TestCase):
             {'mydate': '2010-01-02'}
         ).mydate == datetime.datetime(2010, 1, 2)
 
+        assert properties.DateTime('').equal(datetime.datetime(2010, 1, 2),
+                                             datetime.datetime(2010, 1, 2))
+        assert not properties.DateTime('').equal(datetime.datetime(2010, 1, 2),
+                                                 datetime.datetime(2010, 1, 3))
+
     def test_uid(self):
 
         class UidModel(properties.HasProperties):
@@ -441,6 +470,8 @@ class TestBasic(unittest.TestCase):
 
         assert properties.Uuid.to_json(json_uuid) == json_uuid_str
         assert str(properties.Uuid.from_json(json_uuid_str)) == json_uuid_str
+
+        assert properties.Uuid('').equal(uuid.UUID(int=0), uuid.UUID(int=0))
 
     def test_file(self):
 
@@ -505,6 +536,13 @@ class TestBasic(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             fopt.myfile_read = fopt.myfile_nomode
+
+        fopen = open(fname, 'wb')
+        assert properties.File('').equal(fopen, fopen)
+        fopen_again = open(fname, 'wb')
+        assert not properties.File('').equal(fopen, fopen_again)
+        fopen.close()
+        fopen_again.close()
 
         os.remove(fname)
 

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -204,6 +204,17 @@ class TestDefault(unittest.TestCase):
             assert len(w) > 0
             assert issubclass(w[0].category, RuntimeWarning)
 
+        def twelve():
+            return 12
+
+        HasUnionD._props['d'].default = twelve
+        hu = HasUnionD()
+        assert hu.d == 12
+        HasUnionD._props['d'].default = properties.undefined
+        hu = HasUnionD()
+        assert hu.d is None
+
+
     def test_instance_default(self):
         class HasInt(properties.HasProperties):
             a = properties.Integer('int a')

--- a/tests/test_dynamic.py
+++ b/tests/test_dynamic.py
@@ -45,6 +45,10 @@ class TestDynamic(unittest.TestCase):
         with self.assertRaises(AttributeError):
             del hdp.my_doubled_int
 
+        assert HasDynamicProperty._props['my_vector'].equal(
+            vectormath.Vector3(0, 1, 2), vectormath.Vector3(0, 1, 2)
+        )
+
     def test_dynamic_setter(self):
 
         class HasDynamicProperty(properties.HasProperties):

--- a/tests/test_dynamic.py
+++ b/tests/test_dynamic.py
@@ -200,6 +200,25 @@ class TestDynamic(unittest.TestCase):
                 def my_doubled_int(self, extra):
                     del self.my_float
 
+        with self.assertRaises(TypeError):
+            class HasDynamicProperty(properties.HasProperties):
+                my_float = properties.Float('a float')
+
+                @properties.Integer('a dynamic int', default = 10)
+                def my_doubled_int(self):
+                    return self.my_float*2
+
+        with self.assertRaises(TypeError):
+            class HasDynamicProperty(properties.HasProperties):
+                my_float = properties.Float('a float')
+
+                @properties.Integer('a dynamic int')
+                def my_doubled_int(self):
+                    return self.my_float*2
+
+            HasDynamicProperty._props['my_doubled_int'].name = 5
+
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -97,6 +97,16 @@ class TestInstance(unittest.TestCase):
 
         assert hf.serialize(include_class=False) == {'myfloatinst': 0.5}
 
+        sc = SomeClass()
+        assert properties.Instance('', SomeClass).equal(sc, sc)
+        assert not properties.Instance('', SomeClass).equal(sc, SomeClass())
+
+        hia = HasIntA()
+        assert properties.Instance('', HasIntA).equal(hia, hia)
+        assert properties.Instance('', HasIntA).equal(HasIntA(), HasIntA())
+        assert not properties.Instance('', HasIntA).equal(HasIntA(5),
+                                                          HasIntA(1))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -129,6 +129,17 @@ class TestList(unittest.TestCase):
 
         assert HasIntAList._props['mylist'].deserialize(None) is None
 
+        assert properties.List('', properties.Instance('', HasIntA)).equal(
+            [HasIntA(a=1), HasIntA(a=2)], [HasIntA(a=1), HasIntA(a=2)]
+        )
+        assert not properties.List('', properties.Instance('', HasIntA)).equal(
+            [HasIntA(a=1), HasIntA(a=2)],
+            [HasIntA(a=1), HasIntA(a=2), HasIntA(a=3)]
+        )
+        assert not properties.List('', properties.Instance('', HasIntA)).equal(
+            [HasIntA(a=1), HasIntA(a=2)], [HasIntA(a=1), HasIntA(a=3)]
+        )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -127,6 +127,12 @@ class TestList(unittest.TestCase):
         assert isinstance(deser_list[1], HasIntA) and deser_list[1].a == 10
         assert isinstance(deser_list[2], HasIntA) and deser_list[2].a == 100
 
+        class HasOptionalList(properties.HasProperties):
+            mylist = properties.List('', properties.Bool(''), required=False)
+
+        hol = HasOptionalList()
+        hol.validate()
+
         assert HasIntAList._props['mylist'].deserialize(None) is None
 
         assert properties.List('', properties.Instance('', HasIntA)).equal(
@@ -139,6 +145,7 @@ class TestList(unittest.TestCase):
         assert not properties.List('', properties.Instance('', HasIntA)).equal(
             [HasIntA(a=1), HasIntA(a=2)], [HasIntA(a=1), HasIntA(a=3)]
         )
+        assert not properties.List('', properties.Integer('')).equal(5, 5)
 
 
 if __name__ == '__main__':

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -54,8 +54,6 @@ class TestMath(unittest.TestCase):
 
         arrays.myarraybool = np.array([0, 1, 0]).astype(bool)
 
-
-
         assert properties.Array.to_json(
             np.array([[0., 1., np.nan, np.inf]])
         ) == [[0., 1., 'nan', 'inf']]
@@ -78,6 +76,11 @@ class TestMath(unittest.TestCase):
         ).myarrayint == np.array([0, 1, 2]))
 
         assert ArrayOpts._props['myarrayint'].deserialize(None) is None
+
+        assert properties.Array('').equal(np.array([1., 2., 3.]),
+                                          np.array([1., 2., 3.]))
+        assert not properties.Array('').equal(np.array([1., 2., 3.]),
+                                              [1., 2., 3.])
 
     def test_vector2(self):
 
@@ -116,6 +119,11 @@ class TestMath(unittest.TestCase):
         with self.assertRaises(ZeroDivisionError):
             hv2.vec2 = [0., 0.]
 
+        assert properties.Vector2('').equal(vmath.Vector2(1., 2.),
+                                            vmath.Vector2(1., 2.))
+        assert not properties.Vector2('').equal(vmath.Vector2(1., 2.),
+                                                np.array([1., 2.]))
+
 
     def test_vector3(self):
 
@@ -144,6 +152,11 @@ class TestMath(unittest.TestCase):
         assert isinstance(properties.Vector3.from_json([5., 6., 7.]),
                           vmath.Vector3)
 
+        assert properties.Vector3('').equal(vmath.Vector3(1., 2., 3.),
+                                            vmath.Vector3(1., 2., 3.))
+        assert not properties.Vector3('').equal(vmath.Vector3(1., 2., 3.),
+                                                np.array([1., 2., 3.]))
+
     def test_vector2array(self):
 
         class HasVec2Arr(properties.HasProperties):
@@ -171,6 +184,14 @@ class TestMath(unittest.TestCase):
         assert isinstance(
             properties.Vector2Array.from_json([[5., 6.], [7., 8.]]),
             vmath.Vector2Array
+        )
+        assert properties.Vector2Array('').equal(
+            vmath.Vector2Array([[5., 6.], [7., 8.]]),
+            vmath.Vector2Array([[5., 6.], [7., 8.]])
+        )
+        assert not properties.Vector2Array('').equal(
+            vmath.Vector2Array([[5., 6.], [7., 8.]]),
+            np.array([[5., 6.], [7., 8.]])
         )
 
     def test_vector3array(self):
@@ -204,6 +225,19 @@ class TestMath(unittest.TestCase):
             properties.Vector3Array.from_json([[4., 5., 6.], [7., 8., 9.]]),
             vmath.Vector3Array
         )
+        assert properties.Vector3Array('').equal(
+            vmath.Vector3Array([[4., 5., 6.], [7., 8., 9.]]),
+            vmath.Vector3Array([[4., 5., 6.], [7., 8., 9.]])
+        )
+        assert not properties.Vector3Array('').equal(
+            vmath.Vector3Array([[4., 5., 6.], [7., 8., 9.]]),
+            vmath.Vector3Array([[4., 5., 6.]])
+        )
+        assert not properties.Vector3Array('').equal(
+            vmath.Vector3Array([[4., 5., 6.], [7., 8., 9.]]),
+            np.array([[4., 5., 6.], [7., 8., 9.]])
+        )
+        assert not properties.Vector3Array('').equal('hi', 'hi')
 
 
 if __name__ == '__main__':

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -51,6 +51,8 @@ class TestMath(unittest.TestCase):
             arrays.myarrayint = np.array([0, 1, 0]).astype(bool)
         with self.assertRaises(ValueError):
             arrays.myarraybool = np.array(['a', 'b', 'c'])
+        with self.assertRaises(ValueError):
+            properties.Array('').validate(None, [[1., 2.]])
 
         arrays.myarraybool = np.array([0, 1, 0]).astype(bool)
 

--- a/tests/test_recursion.py
+++ b/tests/test_recursion.py
@@ -30,6 +30,19 @@ class TestRecursion(unittest.TestCase):
         with self.assertRaises(ValueError):
             hhp.validate()
 
+        class HasRecursion(properties.HasProperties):
+
+            def twelve(self):
+                return 12
+
+            @properties.stop_recursion_with(twelve)
+            def add_one_recursively(self):
+                return self.add_one_recursively() + 1
+
+        hr = HasRecursion()
+
+        assert hr.add_one_recursively() == 13
+
     def test_list_recursion(self):
 
         class HasInteger(properties.HasProperties):

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -94,6 +94,18 @@ class TestSerialization(unittest.TestCase):
             properties.HasProperties.deserialize(hp3_dict, trusted=True), HP3
         )
 
+        with self.assertRaises(ValueError):
+            HP1.deserialize(5)
+
+    def test_immutable_serial(self):
+
+        class UidModel(properties.HasProperties):
+            uid = properties.Uuid('unique id')
+
+        um1 = UidModel()
+        um2 = UidModel.deserialize(um1.serialize())
+        assert um1 == um2
+
     def test_none_serial(self):
 
         class ManyProperties(properties.HasProperties):

--- a/tests/test_union.py
+++ b/tests/test_union.py
@@ -86,6 +86,18 @@ class TestUnion(unittest.TestCase):
 
         assert HasIntAndList._props['myints'].deserialize(None) is None
 
+        union_prop = properties.Union(
+            doc='',
+            props=[properties.Instance('', HasDummyUnion),
+                   properties.String('')]
+        )
+        assert union_prop.equal('hi', 'hi')
+        hdu = HasDummyUnion()
+        assert union_prop.equal(hdu, hdu)
+        assert union_prop.equal(hdu, HasDummyUnion())
+        assert not union_prop.equal(hdu, 'hi')
+
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This is currently used with `assert_valid` to ensure property values were not modified in a way that skipped validation.

- This lays the groundwork for a new listener that only fires on changes rather than every time it is set