### PR TITLE
[IMP] ReadMe: Add docs link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,6 +54,11 @@ Goals
 * Prioritize documentation
 * Connect to other libraries for interactive visualizations
 
+Documentation
+-------------
+
+API Documentation is available at `ReadTheDocs <https://propertiespy.readthedocs.io/en/latest/>`_.
+
 Alternatives
 ------------
 


### PR DESCRIPTION
I don't want to admit how long it took me to find the API docs, only to find that they were also in the GitHub project description.

With that in mind I think the docs should be in the ReadMe as well, so this PR adds a `Documentation` section under scope. I didn't see any other good spots for it, although maybe just adding the note in `Examples` section would be better.

* Add link to documentation on ReadTheDocs into ReadMe