### PR TITLE
copy and equal functions

### DIFF
--- a/docs/content/hasproperties.rst
+++ b/docs/content/hasproperties.rst
@@ -4,11 +4,23 @@ HasProperties
 =============
 
 .. autoclass:: properties.HasProperties
-    :members: validate, serialize, deserialize, equal
+    :members: validate, serialize, deserialize
 
 .. autoclass:: properties.base.PropertyMetaclass
 
-.. rubric:: HasProperties Features
+|
+|
+
+.. rubric:: Functions that act on HasProperties instances:
+
+.. autofunction:: properties.copy
+
+.. autofunction:: properties.equal
+
+|
+|
+
+.. rubric:: HasProperties features:
 
 * :ref:`documentation` - Classes are auto-documented with
   a sphinx-style docstring.

--- a/properties/__init__.py
+++ b/properties/__init__.py
@@ -9,10 +9,6 @@ import properties
 class Profile(properties.HasProperties):
     name = properties.String('What is your name?')
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from .base import (
     HasProperties,
@@ -82,7 +78,7 @@ from .utils import (
     undefined,
 )
 
-__version__ = '0.3.2'
-__author__ = '3point Science'
-__license__ = 'MIT'
-__copyright__ = 'Copyright 2017 3point Science,'
+__version__ = u'0.3.2'
+__author__ = u'3point Science'
+__license__ = u'MIT'
+__copyright__ = u'Copyright 2017 3point Science,'

--- a/properties/__init__.py
+++ b/properties/__init__.py
@@ -21,6 +21,8 @@ from .base import (
     Set,
     Tuple,
     Union,
+    copy,
+    equal,
 )
 
 from .basic import (

--- a/properties/__init__.py
+++ b/properties/__init__.py
@@ -9,6 +9,10 @@ import properties
 class Profile(properties.HasProperties):
     name = properties.String('What is your name?')
 """
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 from .base import (
     HasProperties,
@@ -78,7 +82,13 @@ from .utils import (
     undefined,
 )
 
-__version__ = u'0.3.2'
-__author__ = u'3point Science'
-__license__ = u'MIT'
-__copyright__ = u'Copyright 2017 3point Science,'
+__version__ = '0.3.2'
+__author__ = '3point Science'
+__license__ = 'MIT'
+__copyright__ = 'Copyright 2017 3point Science,'
+
+try:
+    del absolute_import, division, print_function, unicode_literals
+except NameError:
+    # Error cleaning namespace
+    pass

--- a/properties/base/base.py
+++ b/properties/base/base.py
@@ -452,6 +452,12 @@ def equal(value_a, value_b):
     HasProperties instance (eg. :code:`value_a is value_b`) this method
     returns True. Finally, if either value is not a HasProperties
     instance, equality is simply checked with ==.
+
+    .. note::
+
+        HasProperties objects with recursive self-references will not
+        evaluate to equal, even if their property values and structure
+        are equivalent.
     """
     if (
             not isinstance(value_a, HasProperties) or

--- a/properties/base/base.py
+++ b/properties/base/base.py
@@ -436,12 +436,35 @@ class HasProperties(with_metaclass(PropertyMetaclass, object)):
         Equivalence is determined by checking if all Property values on
         two instances are equal, using :code:`Property.equal`.
         """
-        if self is other:
-            return True
-        if not isinstance(other, self.__class__):
-            return False
-        for prop in itervalues(self._props):
-            if prop.equal(getattr(self, prop.name), getattr(other, prop.name)):
-                continue
-            return False
+        warn('HasProperties.equal has been depricated in favor of '
+             'properties.equal and will be removed in the next release',
+             FutureWarning)
+        return equal(self, other)
+
+
+@utils.stop_recursion_with(False)
+def equal(value_a, value_b):
+    """Determine if two **HasProperties** instances are equivalent
+
+    Equivalence is determined by checking if (1) the two instances are
+    the same class and (2) all Property values on two instances are
+    equal, using :code:`Property.equal`. If the two values are the same
+    HasProperties instance (eg. :code:`value_a is value_b`) this method
+    returns True. Finally, if either value is not a HasProperties
+    instance, equality is simply checked with ==.
+    """
+    if (
+            not isinstance(value_a, HasProperties) or
+            not isinstance(value_b, HasProperties)
+    ):
+        return value_a == value_b
+    if value_a is value_b:
         return True
+    if value_a.__class__ is not value_b.__class__:
+        return False
+    for prop in itervalues(value_a._props):
+        if prop.equal(getattr(value_a, prop.name),
+                      getattr(value_b, prop.name)):
+            continue
+        return False
+    return True

--- a/properties/base/base.py
+++ b/properties/base/base.py
@@ -468,3 +468,19 @@ def equal(value_a, value_b):
             continue
         return False
     return True
+
+
+def copy(value, **kwargs):
+    """Return a copy of a **HasProperties** instance
+
+    A copy is produced by serializing the HasProperties instance then
+    deserializing it to a new instance. Therefore, if any properties
+    cannot be serialized/deserialized, :code:`copy` will fail. Any
+    keyword arguments will be passed through to both :code:`serialize`
+    and :code:`deserialize`.
+    """
+
+    if not isinstance(value, HasProperties):
+        raise ValueError('properties.copy may only be used to copy'
+                         'HasProperties instances')
+    return value.__class__.deserialize(value.serialize(**kwargs), **kwargs)

--- a/properties/base/base.py
+++ b/properties/base/base.py
@@ -469,6 +469,12 @@ def equal(value_a, value_b):
     if value_a.__class__ is not value_b.__class__:
         return False
     for prop in itervalues(value_a._props):
+        prop_a = getattr(value_a, prop.name)
+        prop_b = getattr(value_b, prop.name)
+        if prop_a is None and prop_b is None:
+            continue
+        if prop_a is None or prop_b is None:
+            return False
         if prop.equal(getattr(value_a, prop.name),
                       getattr(value_b, prop.name)):
             continue

--- a/properties/base/instance.py
+++ b/properties/base/instance.py
@@ -7,7 +7,7 @@ from __future__ import unicode_literals
 import json
 from six import PY2
 
-from .base import HasProperties
+from .base import HasProperties, equal
 from .. import basic
 from .. import utils
 
@@ -144,7 +144,7 @@ class Instance(basic.Property):
 
     def equal(self, value_a, value_b):
         if isinstance(value_a, HasProperties):
-            return value_a.equal(value_b)
+            return equal(value_a, value_b)
         return value_a is value_b
 
     @staticmethod

--- a/properties/base/instance.py
+++ b/properties/base/instance.py
@@ -143,9 +143,7 @@ class Instance(basic.Property):
         return self.from_json(value, **kwargs)
 
     def equal(self, value_a, value_b):
-        if isinstance(value_a, HasProperties):
-            return equal(value_a, value_b)
-        return value_a is value_b
+        return equal(value_a, value_b)
 
     @staticmethod
     def to_json(value, **kwargs):

--- a/properties/base/instance.py
+++ b/properties/base/instance.py
@@ -165,7 +165,7 @@ class Instance(basic.Property):
     def from_json(value, **kwargs):
         """Instance properties cannot statically convert from JSON"""
         raise TypeError("Instance properties cannot statically convert "
-                        "values from JSON. 'eserialize' must be used on an "
+                        "values from JSON. 'deserialize' must be used on an "
                         "instance of Instance Property instead, and if the "
                         "instance_class is not a HasProperties subclass a "
                         "custom deserializer must be registered")

--- a/properties/basic.py
+++ b/properties/basic.py
@@ -511,7 +511,7 @@ class DynamicProperty(GettableProperty):                                       #
         return getattr(self, '_del_func', None)
 
     def get_property(self):
-        """Establishes the dynamic behaviour of Property values"""
+        """Establishes the dynamic behavior of Property values"""
         scope = self
 
         def fget(self):

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -83,7 +83,9 @@ class TestBasic(unittest.TestCase):
             assert issubclass(w[0].category, FutureWarning)
 
         assert properties.equal(PropOpts(), PropOpts())
-        assert not PropOpts(myprop=5).equal(PropOpts())
+        assert properties.equal(PropOpts(myprop=5), PropOpts(myprop=5))
+        assert not properties.equal(PropOpts(myprop=5), PropOpts())
+        assert not properties.equal(PropOpts(myprop=5), PropOpts(myprop=6))
 
         with self.assertRaises(AttributeError):
             class BadDocOrder(properties.HasProperties):

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -77,7 +77,12 @@ class TestBasic(unittest.TestCase):
 
         assert PropOpts(myprop=5).validate()
 
-        assert PropOpts().equal(PropOpts())
+        with warnings.catch_warnings(record=True) as w:
+            assert PropOpts().equal(PropOpts())
+            assert len(w) == 1
+            assert issubclass(w[0].category, FutureWarning)
+
+        assert properties.equal(PropOpts(), PropOpts())
         assert not PropOpts(myprop=5).equal(PropOpts())
 
         with self.assertRaises(AttributeError):
@@ -641,6 +646,33 @@ class TestBasic(unittest.TestCase):
 
         assert myp.my_int is None
 
+    def test_copy(self):
+
+        class HasProps2(properties.HasProperties):
+            my_list = properties.List('my list', properties.Bool(''))
+            five = properties.GettableProperty('five', default=5)
+            my_array = properties.Vector3Array('my array')
+
+        class HasProps1(properties.HasProperties):
+            my_hp2 = properties.Instance('my HasProps2', HasProps2)
+            my_union = properties.Union(
+                'string or int',
+                (properties.String(''), properties.Integer(''))
+            )
+
+        hp1 = HasProps1(
+            my_hp2=HasProps2(
+                my_list=[True, True, False],
+                my_array=[[1., 2., 3.], [4., 5., 6.]],
+            ),
+            my_union=10,
+        )
+        hp1_copy = properties.copy(hp1)
+        assert properties.equal(hp1, hp1_copy)
+        assert hp1 is not hp1_copy
+        assert hp1.my_hp2 is not hp1_copy.my_hp2
+        assert hp1.my_hp2.my_list is not hp1_copy.my_hp2.my_list
+        assert hp1.my_hp2.my_array is not hp1_copy.my_hp2.my_array
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -464,22 +464,19 @@ class TestContainer(unittest.TestCase):
         class HasIntA(properties.HasProperties):
             a = properties.Integer('int a', required=True)
 
+        hia_json = properties.Set.to_json({HasIntA(a=5), HasIntA(a=10)})
         assert (
-            properties.Set.to_json(
-                {HasIntA(a=5), HasIntA(a=10)}
-            ) == [{'__class__': 'HasIntA', 'a': 5},
-                  {'__class__': 'HasIntA', 'a': 10}] or
-            properties.Set.to_json(
-                {HasIntA(a=5), HasIntA(a=10)}
-            ) == [{'__class__': 'HasIntA', 'a': 10},
-                  {'__class__': 'HasIntA', 'a': 5}]
+            hia_json == [{'__class__': 'HasIntA', 'a': 5},
+                         {'__class__': 'HasIntA', 'a': 10}] or
+            hia_json == [{'__class__': 'HasIntA', 'a': 10},
+                         {'__class__': 'HasIntA', 'a': 5}]
         )
 
-        assert li.serialize(include_class=False) == {
-            'ccc': [[255, 0, 0], [0, 255, 0]]
-        } or li.serialize(include_class=False) == {
-            'ccc': [[0, 255, 0], [255, 0, 0]]
-        }
+        li_ser = li.serialize(include_class=False)
+        assert (
+            li_ser == {'ccc': [[255, 0, 0], [0, 255, 0]]} or
+            li_ser == {'ccc': [[0, 255, 0], [255, 0, 0]]}
+        )
 
         class HasIntASet(properties.HasProperties):
             myset = properties.Set('set of HasIntA', HasIntA,

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -104,7 +104,7 @@ class TestSerialization(unittest.TestCase):
 
         um1 = UidModel()
         um2 = UidModel.deserialize(um1.serialize())
-        assert um1.equal(um2)
+        assert properties.equal(um1, um2)
 
     def test_none_serial(self):
 


### PR DESCRIPTION
This PR introduces `properties.copy` to copy a HasProperties instance. It simply serializes an instance then deserializes to a new instance. Also moves `HasProperties.equal` to `properties.equal` without modifying the functionality.

At a higher-lever, this sets a precedent for keeping `HasProperties` namespace as clean as possible so the properties are very accessible.