### PR TITLE
Fix properties.Property.equal bug

### DIFF
--- a/properties/base/base.py
+++ b/properties/base/base.py
@@ -267,14 +267,20 @@ class HasProperties(with_metaclass(PropertyMetaclass, object)):
             listener.func(self, change)
 
     def _set(self, name, value):
-        prev = self._get(name)
+        prev = self._backend.get(name, utils.undefined)
         change = dict(name=name, previous=prev, value=value, mode='validate')
         self._notify(change)
         if change['value'] is utils.undefined:
             self._backend.pop(name, None)
         else:
             self._backend[name] = change['value']
-        if not self._props[name].equal(prev, change['value']):
+        if prev is utils.undefined and change['value'] is utils.undefined:
+            pass
+        elif(
+                prev is utils.undefined or
+                change['value'] is utils.undefined or
+                not self._props[name].equal(prev, change['value'])
+        ):
             change.update(name=name, previous=prev, mode='observe_change')
             self._notify(change)
         change.update(name=name, previous=prev, mode='observe_set')

--- a/properties/basic.py
+++ b/properties/basic.py
@@ -247,8 +247,17 @@ class GettableProperty(with_metaclass(ArgumentWrangler, object)):              #
         return True
 
     def equal(self, value_a, value_b):                                         #pylint: disable=no-self-use
-        """Check if two valid Property values are equal"""
-        return value_a == value_b
+        """Check if two valid Property values are equal
+
+        .. note::
+
+            This method assumes that :code:`None` and
+            :code:`properties.undefined` are never passed in as values
+        """
+        equal = value_a == value_b
+        if hasattr(equal, '__iter__'):
+            return all(equal)
+        return equal
 
     def get_property(self):
         """Establishes access of GettableProperty values"""

--- a/properties/handlers.py
+++ b/properties/handlers.py
@@ -207,8 +207,10 @@ def observer(names_or_instance, names=None, func=None, change_only=False):
     This dictionary contains:
 
     * 'name' - the name of the changed Property
-    * 'previous' - the value of the Property prior to change
-    * 'value' - the new value of the Property
+    * 'previous' - the value of the Property prior to change (this will be
+      :code:`properties.undefined` if the value was not previously set)
+    * 'value' - the new value of the Property (this will be
+      :code:`properties.undefined` if the value is deleted)
     * 'mode' - the mode of the change; for observers, this is either
       'observe_set' or 'observe_change'
 
@@ -274,8 +276,10 @@ def validator(names_or_instance, names=None, func=None):
     This dictionary contains:
 
     * 'name' - the name of the changed Property
-    * 'previous' - the value of the Property prior to change
-    * 'value' - the new value of the Property
+    * 'previous' - the value of the Property prior to change (this will be
+      :code:`properties.undefined` if the value was not previously set)
+    * 'value' - the new value of the Property (this will be
+      :code:`properties.undefined` if the value is deleted)
     * 'mode' - the mode of the change; for validators, this is 'validate'
 
     **Mode 2:**

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -108,6 +108,13 @@ class TestBasic(unittest.TestCase):
         class NoMoreDocOrder(WithDocOrder):
             _doc_order = None
 
+        assert properties.Property('').equal(5, 5)
+        assert not properties.Property('').equal(5, 'hi')
+        assert properties.Property('').equal(np.array([1., 2.]),
+                                             np.array([1., 2.]))
+        assert not properties.Property('').equal(np.array([1., 2.]),
+                                                 np.array([3., 4.]))
+
     def test_bool(self):
 
         class BoolOpts(properties.HasProperties):

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -83,6 +83,14 @@ class TestMath(unittest.TestCase):
                                           np.array([1., 2., 3.]))
         assert not properties.Array('').equal(np.array([1., 2., 3.]),
                                               [1., 2., 3.])
+        assert properties.Array('').equal(np.array([1., 2., np.nan, np.nan]),
+                                          np.array([1., 2., np.nan, np.nan]))
+        assert properties.Array('').equal(np.array([1., 2., np.inf, np.nan]),
+                                          np.array([1., 2., np.inf, np.nan]))
+        assert not properties.Array('').equal(
+            np.array([1., 2., np.nan, np.nan]),
+            np.array([1., 2., np.inf, np.nan])
+        )
 
     def test_vector2(self):
 


### PR DESCRIPTION
Since `properties.Property.equal` simply used `==` it could return an array of booleans given certain input type (eg. numpy array). This fix now causes `properties.Property.equal` to return a single bool if `==` returns an iterable.

This PR also includes a bit of constraint on `equal` and change notification input. Namely `None`/`properties.undefined` should never be passed to `equal`, and `properties.undefined` will be used as `previous` and `value` in the change notification dictionary if no value is defined (as opposed to `None`).